### PR TITLE
extra check for equal family size to avoid triangular delitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## v1.2.0 - [date]
 
+### `Fixed`
+
+- [#80](https://github.com/nf-core/proteinfamilies/pull/80) - Fixed a bug where, due to a missing check for equal family sizes, non-redundant families were erroneously marked as redundant through transitive relationships and were removed
+
 ## v1.1.1 - [2025/05/17]
 
 ### `Changed`

--- a/bin/identify_redundant_fams.py
+++ b/bin/identify_redundant_fams.py
@@ -90,10 +90,17 @@ def remove_redundant_fams(mapping, domtbl, length_threshold, out_file):
 
     redundant_fam_names = set()
     for _, row in domtbl_df.iterrows():
-        if int(row["query size"]) < int(row["target size"]):
-            redundant_fam_names.add(row["query name"])
-        else:
-            redundant_fam_names.add(row["target name"])
+        query = row["query name"]
+        target = row["target name"]
+        query_size = int(row["query size"])
+        target_size = int(row["target size"])
+
+        if query_size < target_size:
+            redundant_fam_names.add(query)
+        elif target_size < query_size:
+            redundant_fam_names.add(target)
+        else: # sizes equal, keep alphabetically first as non-redundant to avoid triangular deletions
+            redundant_fam_names.add(max(query, target))
 
     with open(out_file, "w") as f:
         for name in sorted(redundant_fam_names):


### PR DESCRIPTION
## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/proteinfamilies/tree/main/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/proteinfamilies _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
