### PR TITLE
extract_family_reps update

### DIFF
--- a/bin/extract_family_reps.py
+++ b/bin/extract_family_reps.py
@@ -71,41 +71,45 @@ def extract_first_sequences(msa_folder, metadata_file, out_fasta):
         # Iterate over all files in the MSA folder
         for filename in os.listdir(msa_folder):
             filepath = os.path.join(msa_folder, filename)
-            # Parse the MSA fasta file and extract the first sequence
-            with (
-                gzip.open(filepath, "rt")
-                if filepath.endswith(".gz")
-                else open(filepath, "r")
-            ) as fasta_file:
-                format = "stockholm" if filepath.endswith(".sto.gz") else "fasta"
-                records = list(SeqIO.parse(fasta_file, format))
-                family_size = len(records)
-                if records:
-                    first_record = records[0]
-                    # Remove gaps from the sequence, and convert all to upper case
-                    cleaned_sequence = (
-                        str(first_record.seq).replace("-", "").replace(".", "").upper()
-                    )
-                    # Modify the ID to only include the part before the first space
-                    cleaned_id = first_record.id.split(" ")[0]
-                    # Create a new SeqRecord with the cleaned sequence and ID
-                    cleaned_record = SeqRecord(
-                        Seq(cleaned_sequence), id=cleaned_id, description=""
-                    )
-                    # Write the cleaned sequence to the FASTA file
-                    SeqIO.write(cleaned_record, fasta_out, "fasta")
-                    # Write the mapping to the CSV file
-                    family_name = os.path.splitext(os.path.splitext(filename)[0])[0]
-                    csv_writer.writerow(
-                        [
-                            family_name,
-                            family_name,
-                            family_size,
-                            len(cleaned_sequence),
-                            cleaned_id,
-                            cleaned_sequence,
-                        ]
-                    )
+            format = "stockholm" if filepath.endswith(".sto.gz") else "fasta"
+
+            open_func = gzip.open if filepath.endswith(".gz") else open
+            with open_func(filepath, "rt") as fasta_file:
+                parser = SeqIO.parse(fasta_file, format)
+                try:
+                    # Only read first sequence
+                    first_record = next(parser)
+                    # Then count remaining records to get total family size without storing in memory
+                    family_size = 1 + sum(1 for _ in parser)
+                except StopIteration:
+                    first_record = None
+                    family_size = 0
+
+            if first_record:
+                # Remove gaps from the sequence, and convert all to upper case
+                cleaned_sequence = (
+                    str(first_record.seq).replace("-", "").replace(".", "").upper()
+                )
+                # Modify the ID to only include the part before the first space
+                cleaned_id = first_record.id.split(" ")[0]
+                # Create a new SeqRecord with the cleaned sequence and ID
+                cleaned_record = SeqRecord(
+                    Seq(cleaned_sequence), id=cleaned_id, description=""
+                )
+                # Write the cleaned sequence to the FASTA file
+                SeqIO.write(cleaned_record, fasta_out, "fasta")
+                # Write the mapping to the CSV file
+                family_name = os.path.splitext(os.path.splitext(filename)[0])[0]
+                csv_writer.writerow(
+                    [
+                        family_name,
+                        family_name,
+                        family_size,
+                        len(cleaned_sequence),
+                        cleaned_id,
+                        cleaned_sequence,
+                    ]
+                )
 
 
 def main(args=None):

--- a/modules/local/extract_family_reps/environment.yml
+++ b/modules/local/extract_family_reps/environment.yml
@@ -2,4 +2,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - conda-forge::biopython=1.84
+  - conda-forge::biopython=1.85

--- a/modules/local/extract_family_reps/main.nf
+++ b/modules/local/extract_family_reps/main.nf
@@ -4,27 +4,40 @@ process EXTRACT_FAMILY_REPS {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/eb/eb3700531c7ec639f59f084ab64c05e881d654dcf829db163539f2f0b095e09d/data' :
-        'community.wave.seqera.io/library/biopython:1.84--3318633dad0031e7' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/83/8372f6241b480332d91bc00a88ec8c72c8f7fcc9994177a5dd67a07007cd6e32/data' :
+        'community.wave.seqera.io/library/biopython:1.85--6f761292fa9881b4' }"
 
     input:
     tuple val(meta), path(aln, stageAs: "aln/*")
 
     output:
-    tuple val(meta), path("${meta.id}_reps.faa")    , emit: fasta
-    tuple val(meta), path("${meta.id}_meta_mqc.csv"), emit: map
-    path "versions.yml"                             , emit: versions
+    tuple val(meta), path("${prefix}_reps.faa")    , emit: fasta
+    tuple val(meta), path("${prefix}_meta_mqc.csv"), emit: map
+    path "versions.yml"                            , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
 
     script:
-    def prefix = task.ext.prefix ?: "${meta.id}"
+    prefix = task.ext.prefix ?: "${meta.id}"
     """
     extract_family_reps.py \\
         --full_msa_folder aln \\
         --metadata ${prefix}_meta_mqc.csv \\
         --out_fasta ${prefix}_reps.faa
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        python: \$(python --version 2>&1 | sed 's/Python //g')
+        biopython: \$(python -c "import importlib.metadata; print(importlib.metadata.version('biopython'))")
+    END_VERSIONS
+    """
+
+    stub:
+    prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}_reps.faa
+    touch ${prefix}_meta_mqc.csv
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/extract_family_reps/meta.yml
+++ b/modules/local/extract_family_reps/meta.yml
@@ -1,0 +1,59 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "extract_family_reps"
+description: From a list of alignment files (Stockholm or fasta format) extract a fasta file with the first sequences of each file, as well as a MultiQC CSV with metadata.
+keywords:
+  - fasta
+  - representative sequences
+  - multiqc metadata
+tools:
+  - "extract_family_reps":
+      description: "From a list of alignment files (Stockholm or fasta format) extract a fasta file with the first sequences of each file, as well as a MultiQC CSV with metadata."
+      homepage: "https://github.com/nf-core/proteinfamilies/tree/dev/modules/local/extract_family_reps/"
+      documentation: "https://github.com/nf-core/proteinfamilies/tree/dev/modules/local/extract_family_reps/"
+      tool_dev_url: "https://github.com/nf-core/proteinfamilies/tree/dev/modules/local/extract_family_reps/"
+      doi: "10.5281/zenodo.14881993"
+      licence: ["MIT"]
+      identifier: ""
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id:'sample1', single_end:false ]`
+    - aln:
+        type: file
+        description: A list of alignment files that will be staged as a directory. 
+        pattern: "*.{sto.gz,fasta,fasta.gz}"
+output:
+  - fasta:
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1', single_end:false ]`
+      - ${prefix}_reps.faa:
+          type: file
+          description: a fasta file with all family representative sequences
+          pattern: "*_reps.faa"
+  - map:
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1', single_end:false ]`
+      - ${prefix}_meta_mqc.csv:
+          type: file
+          description: |
+            a MultiQC CSV file with all family representative sequence metadata:
+            "Sample Name","Family Id","Size","Representative Length","Representative Id","Sequence"
+          pattern: "*_meta_mqc.csv"
+  - versions:
+      - "versions.yml":
+          type: file
+          description: File containing software versions
+          pattern: "versions.yml"
+authors:
+  - "@vagkaratzas"
+maintainers:
+  - "@vagkaratzas"

--- a/modules/local/extract_family_reps/test/main.nf.test
+++ b/modules/local/extract_family_reps/test/main.nf.test
@@ -1,0 +1,57 @@
+nextflow_process {
+
+    name "Test Process EXTRACT_FAMILY_REPS"
+    script "../main.nf"
+    process "EXTRACT_FAMILY_REPS"
+
+    test("proteinfamilies - aln") {
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id: 'extract_family_reps' ],  // meta map
+                    [
+                        file(params.pipelines_testdata_base_path + 'test_data/subworkflows/mgnifams_test_1.aln', checkIfExists: true),
+                        file(params.pipelines_testdata_base_path + 'test_data/subworkflows/mgnifams_test_2.aln', checkIfExists: true)
+                    ]
+                ])
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("proteinfamilies - aln - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id: 'extract_family_reps' ],  // meta map
+                    [
+                        file(params.pipelines_testdata_base_path + 'test_data/subworkflows/mgnifams_test_1.aln', checkIfExists: true),
+                        file(params.pipelines_testdata_base_path + 'test_data/subworkflows/mgnifams_test_2.aln', checkIfExists: true)
+                    ]
+                ])
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+}

--- a/modules/local/extract_family_reps/test/main.nf.test.snap
+++ b/modules/local/extract_family_reps/test/main.nf.test.snap
@@ -1,0 +1,100 @@
+{
+    "proteinfamilies - aln": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "extract_family_reps"
+                        },
+                        "extract_family_reps_reps.faa:md5,45b6833af9e647f70cbf13c5162c3508"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "extract_family_reps"
+                        },
+                        "extract_family_reps_meta_mqc.csv:md5,6b35848701c69871a9b9030f42f32a5b"
+                    ]
+                ],
+                "2": [
+                    "versions.yml:md5,8a0073a7aebf991081f4b28800b975f4"
+                ],
+                "fasta": [
+                    [
+                        {
+                            "id": "extract_family_reps"
+                        },
+                        "extract_family_reps_reps.faa:md5,45b6833af9e647f70cbf13c5162c3508"
+                    ]
+                ],
+                "map": [
+                    [
+                        {
+                            "id": "extract_family_reps"
+                        },
+                        "extract_family_reps_meta_mqc.csv:md5,6b35848701c69871a9b9030f42f32a5b"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,8a0073a7aebf991081f4b28800b975f4"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.6"
+        },
+        "timestamp": "2025-06-11T15:47:46.699245877"
+    },
+    "proteinfamilies - aln - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "extract_family_reps"
+                        },
+                        "extract_family_reps_reps.faa:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "extract_family_reps"
+                        },
+                        "extract_family_reps_meta_mqc.csv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    "versions.yml:md5,8a0073a7aebf991081f4b28800b975f4"
+                ],
+                "fasta": [
+                    [
+                        {
+                            "id": "extract_family_reps"
+                        },
+                        "extract_family_reps_reps.faa:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "map": [
+                    [
+                        {
+                            "id": "extract_family_reps"
+                        },
+                        "extract_family_reps_meta_mqc.csv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,8a0073a7aebf991081f4b28800b975f4"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.6"
+        },
+        "timestamp": "2025-06-11T15:47:55.234764457"
+    }
+}


### PR DESCRIPTION
optimised extract_family_reps script to not read whole aln to memory now, added nf-test and meta.yml, updated to biopython 1.85

Closes #41 

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/proteinfamilies/tree/main/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/proteinfamilies _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
