### PR TITLE
Parallelize rep extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Changed`
 
+- [#101](https://github.com/nf-core/proteinfamilies/pull/101) - Parallelized execution for the `EXTRACT_FAMILY_REPS` local module.
 - [#100](https://github.com/nf-core/proteinfamilies/pull/100) - `CAT_CAT` module replaced with `FIND_CONCATENATE` to avoid large scale `Argument list too long` errors.
 - [#98](https://github.com/nf-core/proteinfamilies/pull/98) - nf-core tools template update to 3.3.2.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Changed`
 
-- [#101](https://github.com/nf-core/proteinfamilies/pull/101) - Parallelized execution for the `EXTRACT_FAMILY_REPS` local module.
+- [#103](https://github.com/nf-core/proteinfamilies/pull/103) - Parallelized execution for the `EXTRACT_FAMILY_REPS` local module and changed its input from `full_msa` to `fasta`.
 - [#100](https://github.com/nf-core/proteinfamilies/pull/100) - `CAT_CAT` module replaced with `FIND_CONCATENATE` to avoid large scale `Argument list too long` errors.
 - [#98](https://github.com/nf-core/proteinfamilies/pull/98) - nf-core tools template update to 3.3.2.
 

--- a/bin/extract_family_reps.py
+++ b/bin/extract_family_reps.py
@@ -109,8 +109,6 @@ def process_fasta_file(filename, fasta_folder):
         ), or None if data is incomplete.
     """
     filepath = os.path.join(fasta_folder, filename)
-    print(filename)
-    
     family_name = os.path.splitext(os.path.splitext(filename)[0])[0]
 
     header, sequence, size = extract_data(filepath)

--- a/bin/extract_family_reps.py
+++ b/bin/extract_family_reps.py
@@ -26,7 +26,7 @@ def parse_args(args=None):
         "-t",
         "--num_threads",
         type=int,
-        default=1,
+        default=4,
         help="Number of threads to use for parallel processing."
     )
     parser.add_argument(
@@ -48,7 +48,19 @@ def parse_args(args=None):
     return parser.parse_args(args)
 
 
-def parse_first_fasta(filepath):
+def extract_data(filepath):
+    """
+    Extract the first sequence and total number of entries from a FASTA file.
+
+    Args:
+        filepath (str): Path to the FASTA (.fa or .fa.gz) file.
+
+    Returns:
+        tuple: (header, sequence, size), where:
+            header (str): ID of the first sequence.
+            sequence (str): Amino acid sequence (with gaps and dots removed).
+            size (int): Total number of sequences in the file.
+    """
     open_func = gzip.open if filepath.endswith(".gz") else open
     header = None
     seq_lines = []
@@ -78,11 +90,30 @@ def parse_first_fasta(filepath):
     return None, None, size
 
 
-def process_file(filename, fasta_folder):
+def process_fasta_file(filename, fasta_folder):
+    """
+    Process a single FASTA file to extract family and representative sequence info.
+
+    Args:
+        filename (str): Filename of the FASTA file.
+        fasta_folder (str): Directory containing the FASTA files.
+
+    Returns:
+        tuple or None: (
+            sample name (str),
+            family ID (str),
+            family size (int),
+            representative length (int),
+            representative ID (str),
+            representative sequence (str)
+        ), or None if data is incomplete.
+    """
     filepath = os.path.join(fasta_folder, filename)
+    print(filename)
+    
     family_name = os.path.splitext(os.path.splitext(filename)[0])[0]
 
-    header, sequence, size = parse_first_fasta(filepath)
+    header, sequence, size = extract_data(filepath)
     if header and sequence:
         return (
             family_name,           # Sample Name
@@ -95,11 +126,20 @@ def process_file(filename, fasta_folder):
     return None
 
 
-def extract_first_sequences(fasta_folder, num_threads, metadata_file, out_fasta):
+def parse_family_metadata(fasta_folder, num_threads, metadata_file, out_fasta):
+    """
+    Process all FASTA files in a folder, in parallel, and write metadata and representative sequences.
+
+    Args:
+        fasta_folder (str): Folder containing input FASTA files.
+        num_threads (int): Number of threads for parallel processing.
+        metadata_file (str): Path to the output CSV metadata file.
+        out_fasta (str): Path to the output FASTA file of representative sequences.
+    """
     all_files = sorted(os.listdir(fasta_folder))
 
     with ProcessPoolExecutor(max_workers=num_threads) as executor:
-        results = list(executor.map(partial(process_file, fasta_folder=fasta_folder), all_files))
+        results = list(executor.map(partial(process_fasta_file, fasta_folder=fasta_folder), all_files))
 
     with open(out_fasta, "w") as fasta_out, open(metadata_file, "w", newline="") as csv_out:
         # Write custom metadata lines to the metadata file
@@ -129,7 +169,7 @@ def extract_first_sequences(fasta_folder, num_threads, metadata_file, out_fasta)
 
 def main(args=None):
     args = parse_args(args)
-    extract_first_sequences(args.fasta_folder, args.num_threads, args.metadata, args.out_fasta)
+    parse_family_metadata(args.fasta_folder, args.num_threads, args.metadata, args.out_fasta)
 
 
 if __name__ == "__main__":

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -492,7 +492,7 @@ process {
     }
 
     withName: '.*:UPDATE_FAMILIES:REMOVE_REDUNDANT_SEQS' {
-        ext.prefix = { "${meta.family}_${meta.id}" }
+        ext.prefix = { "${meta.family}" }
         tag = { "${meta.family}_${meta.id}" }
         publishDir = [
             path: { "${params.outdir}/update_families/non_redundant_sequences/${meta.id}/" },

--- a/modules/local/extract_family_reps/environment.yml
+++ b/modules/local/extract_family_reps/environment.yml
@@ -2,5 +2,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - python=3.13.1
-  - conda-forge::biopython=1.85
+  - conda-forge::python=3.13.1

--- a/modules/local/extract_family_reps/main.nf
+++ b/modules/local/extract_family_reps/main.nf
@@ -1,6 +1,6 @@
 process EXTRACT_FAMILY_REPS {
     tag "$meta.id"
-    label 'process_single'
+    label 'process_high'
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
@@ -23,6 +23,7 @@ process EXTRACT_FAMILY_REPS {
     """
     extract_family_reps.py \\
         --full_msa_folder aln \\
+        --num_threads ${task.cpus} \\
         --metadata ${prefix}_meta_mqc.csv \\
         --out_fasta ${prefix}_reps.faa
 

--- a/modules/local/extract_family_reps/main.nf
+++ b/modules/local/extract_family_reps/main.nf
@@ -4,11 +4,11 @@ process EXTRACT_FAMILY_REPS {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/83/8372f6241b480332d91bc00a88ec8c72c8f7fcc9994177a5dd67a07007cd6e32/data' :
-        'community.wave.seqera.io/library/biopython:1.85--6f761292fa9881b4' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/7d/7d0fee0217685dc2501570e1dd12076f9466175d0a37335ca424390cffec5fa1/data' :
+        'community.wave.seqera.io/library/python:3.13.1--d00663700fcc8bcf' }"
 
     input:
-    tuple val(meta), path(aln, stageAs: "aln/*")
+    tuple val(meta), path(faa, stageAs: "faa/*")
 
     output:
     tuple val(meta), path("${prefix}_reps.faa")    , emit: fasta
@@ -22,7 +22,7 @@ process EXTRACT_FAMILY_REPS {
     prefix = task.ext.prefix ?: "${meta.id}"
     """
     extract_family_reps.py \\
-        --full_msa_folder aln \\
+        --fasta_folder faa \\
         --num_threads ${task.cpus} \\
         --metadata ${prefix}_meta_mqc.csv \\
         --out_fasta ${prefix}_reps.faa
@@ -30,7 +30,6 @@ process EXTRACT_FAMILY_REPS {
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         python: \$(python --version 2>&1 | sed 's/Python //g')
-        biopython: \$(python -c "import importlib.metadata; print(importlib.metadata.version('biopython'))")
     END_VERSIONS
     """
 
@@ -43,7 +42,6 @@ process EXTRACT_FAMILY_REPS {
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         python: \$(python --version 2>&1 | sed 's/Python //g')
-        biopython: \$(python -c "import importlib.metadata; print(importlib.metadata.version('biopython'))")
     END_VERSIONS
     """
 }

--- a/modules/local/extract_family_reps/test/main.nf.test
+++ b/modules/local/extract_family_reps/test/main.nf.test
@@ -4,7 +4,7 @@ nextflow_process {
     script "../main.nf"
     process "EXTRACT_FAMILY_REPS"
 
-    test("proteinfamilies - aln") {
+    test("proteinfamilies - faa") {
 
         when {
             process {
@@ -12,8 +12,8 @@ nextflow_process {
                 input[0] = Channel.of([
                     [ id: 'extract_family_reps' ],
                     [
-                        file(params.pipelines_testdata_base_path + 'test_data/modules/mgnifams_test_1.aln', checkIfExists: true),
-                        file(params.pipelines_testdata_base_path + 'test_data/modules/mgnifams_test_2.aln', checkIfExists: true)
+                        file(params.pipelines_testdata_base_path + 'test_data/modules/mgnifams_test_1.faa', checkIfExists: true),
+                        file(params.pipelines_testdata_base_path + 'test_data/modules/mgnifams_test_2.faa', checkIfExists: true)
                     ]
                 ])
                 """
@@ -34,7 +34,7 @@ nextflow_process {
         }
     }
 
-    test("proteinfamilies - aln - stub") {
+    test("proteinfamilies - faa - stub") {
 
         options "-stub"
 
@@ -44,8 +44,8 @@ nextflow_process {
                 input[0] = Channel.of([
                     [ id: 'extract_family_reps' ],
                     [
-                        file(params.pipelines_testdata_base_path + 'test_data/modules/mgnifams_test_1.aln', checkIfExists: true),
-                        file(params.pipelines_testdata_base_path + 'test_data/modules/mgnifams_test_2.aln', checkIfExists: true)
+                        file(params.pipelines_testdata_base_path + 'test_data/modules/mgnifams_test_1.faa', checkIfExists: true),
+                        file(params.pipelines_testdata_base_path + 'test_data/modules/mgnifams_test_2.faa', checkIfExists: true)
                     ]
                 ])
                 """

--- a/modules/local/extract_family_reps/test/main.nf.test.snap
+++ b/modules/local/extract_family_reps/test/main.nf.test.snap
@@ -1,15 +1,14 @@
 {
-    "proteinfamilies - aln": {
+    "proteinfamilies - faa": {
         "content": [
             "extract_family_reps_reps.faa",
-            7,
+            4,
             "extract_family_reps_meta_mqc.csv",
             8,
             [
                 {
                     "EXTRACT_FAMILY_REPS": {
-                        "python": "3.13.1",
-                        "biopython": 1.85
+                        "python": "3.13.1"
                     }
                 }
             ]
@@ -18,9 +17,9 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.6"
         },
-        "timestamp": "2025-07-14T14:40:38.452461242"
+        "timestamp": "2025-07-29T11:25:17.775635822"
     },
-    "proteinfamilies - aln - stub": {
+    "proteinfamilies - faa - stub": {
         "content": [
             {
                 "0": [
@@ -40,7 +39,7 @@
                     ]
                 ],
                 "2": [
-                    "versions.yml:md5,8a0073a7aebf991081f4b28800b975f4"
+                    "versions.yml:md5,3f12f02c71ad2d3d5aff7885537cbd9f"
                 ],
                 "fasta": [
                     [
@@ -59,7 +58,7 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,8a0073a7aebf991081f4b28800b975f4"
+                    "versions.yml:md5,3f12f02c71ad2d3d5aff7885537cbd9f"
                 ]
             }
         ],
@@ -67,6 +66,6 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.6"
         },
-        "timestamp": "2025-07-14T14:40:49.087750638"
+        "timestamp": "2025-07-29T11:25:31.692612332"
     }
 }

--- a/modules/local/remove_redundant_seqs/main.nf
+++ b/modules/local/remove_redundant_seqs/main.nf
@@ -12,8 +12,8 @@ process REMOVE_REDUNDANT_SEQS {
     tuple val(meta2), path(sequences)
 
     output:
-    tuple val(meta), path("${prefix}_reps.faa"), emit: fasta
-    path "versions.yml"                        , emit: versions
+    tuple val(meta), path("${prefix}.faa"), emit: fasta
+    path "versions.yml"                   , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -30,7 +30,7 @@ process REMOVE_REDUNDANT_SEQS {
     remove_redundant_seqs.py \\
         --clustering ${clustering} \\
         --sequences ${fasta_name} \\
-        --out_fasta ${prefix}_reps.faa
+        --out_fasta ${prefix}.faa
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
@@ -42,7 +42,7 @@ process REMOVE_REDUNDANT_SEQS {
     stub:
     prefix = task.ext.prefix ?: "${meta.id}"
     """
-    touch ${prefix}_reps.faa
+    touch ${prefix}.faa
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/remove_redundant_seqs/tests/main.nf.test.snap
+++ b/modules/local/remove_redundant_seqs/tests/main.nf.test.snap
@@ -6,7 +6,7 @@
                     {
                         "id": "test_tsv"
                     },
-                    "test_tsv_null_reps.faa:md5,e06dfa1241372e7fe8aa9f8c20c8f8a9"
+                    "test_tsv_null.faa:md5,e06dfa1241372e7fe8aa9f8c20c8f8a9"
                 ]
             ],
             [
@@ -20,9 +20,9 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "25.04.3"
+            "nextflow": "25.04.6"
         },
-        "timestamp": "2025-06-13T15:36:57.405924262"
+        "timestamp": "2025-07-29T13:27:03.735181518"
     },
     "proteinfamilies - tsv - stub": {
         "content": [
@@ -32,7 +32,7 @@
                         {
                             "id": "test_tsv"
                         },
-                        "test_tsv_null_reps.faa:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "test_tsv_null.faa:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "1": [
@@ -43,7 +43,7 @@
                         {
                             "id": "test_tsv"
                         },
-                        "test_tsv_null_reps.faa:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "test_tsv_null.faa:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "versions": [
@@ -53,8 +53,8 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "25.04.3"
+            "nextflow": "25.04.6"
         },
-        "timestamp": "2025-06-13T15:37:17.110306402"
+        "timestamp": "2025-07-29T13:27:14.085707025"
     }
 }

--- a/subworkflows/local/remove_redundancy/tests/main.nf.test
+++ b/subworkflows/local/remove_redundancy/tests/main.nf.test
@@ -73,7 +73,7 @@ nextflow_workflow {
             assertAll(
                 { assert workflow.success},
                 { assert snapshot(
-                    workflow.out.full_msa,
+                    workflow.out.fasta,
                     workflow.out.versions.collect { path(it).yaml }.unique()
                     ).match()}
             )

--- a/subworkflows/local/remove_redundancy/tests/main.nf.test.snap
+++ b/subworkflows/local/remove_redundancy/tests/main.nf.test.snap
@@ -7,14 +7,14 @@
                         "id": "chunk",
                         "chunk": "1"
                     },
-                    "chunk_1.aln:md5,eb65c919dd074c6c25420163675de2c4"
+                    "chunk_1.faa:md5,6a54d12b222346b1df685867c0bdd151"
                 ],
                 [
                     {
                         "id": "chunk",
                         "chunk": "2"
                     },
-                    "chunk_2.aln:md5,ed2a2cbbb5f207f44ddef4781cd75ff7"
+                    "chunk_2.faa:md5,ebcda473387ebd3d1cdeb7179d4915d2"
                 ]
             ],
             [
@@ -32,6 +32,11 @@
                 {
                     "REMOVE_REDUNDANCY:EXECUTE_CLUSTERING:MMSEQS_CREATETSV": {
                         "mmseqs": "17.b804f"
+                    }
+                },
+                {
+                    "REMOVE_REDUNDANCY:EXTRACT_FAMILY_REPS": {
+                        "python": "3.13.1"
                     }
                 },
                 {
@@ -66,12 +71,6 @@
                     }
                 },
                 {
-                    "REMOVE_REDUNDANCY:EXTRACT_FAMILY_REPS": {
-                        "python": "3.13.1",
-                        "biopython": 1.85
-                    }
-                },
-                {
                     "REMOVE_REDUNDANCY:EXECUTE_CLUSTERING:MMSEQS_CREATEDB": {
                         "mmseqs": "17.b804f"
                     }
@@ -94,6 +93,6 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.6"
         },
-        "timestamp": "2025-07-16T11:15:11.459321912"
+        "timestamp": "2025-07-29T13:46:56.057488862"
     }
 }

--- a/subworkflows/local/update_families/tests/main.nf.test.snap
+++ b/subworkflows/local/update_families/tests/main.nf.test.snap
@@ -40,12 +40,6 @@
                     }
                 },
                 {
-                    "UPDATE_FAMILIES:EXTRACT_FAMILY_REPS": {
-                        "python": "3.13.1",
-                        "biopython": 1.85
-                    }
-                },
-                {
                     "UPDATE_FAMILIES:UNTAR_HMM": {
                         "untar": 1.34
                     }
@@ -55,6 +49,11 @@
                         "find": "4.6.0",
                         "pigz": 2.8,
                         "coreutils": 9.4
+                    }
+                },
+                {
+                    "UPDATE_FAMILIES:EXTRACT_FAMILY_REPS": {
+                        "python": "3.13.1"
                     }
                 },
                 {
@@ -100,6 +99,6 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.6"
         },
-        "timestamp": "2025-07-16T11:09:44.184138008"
+        "timestamp": "2025-07-29T13:48:19.782778367"
     }
 }

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -14,8 +14,7 @@
                     "clipkit": "2.4.1"
                 },
                 "EXTRACT_FAMILY_REPS": {
-                    "python": "3.13.1",
-                    "biopython": 1.85
+                    "python": "3.13.1"
                 },
                 "FAMSA_ALIGN": {
                     "famsa": "2.2.2- (2022-10-09)"
@@ -148,6 +147,6 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.6"
         },
-        "timestamp": "2025-07-22T16:23:32.2133979"
+        "timestamp": "2025-07-29T13:51:45.554009051"
     }
 }

--- a/workflows/proteinfamilies.nf
+++ b/workflows/proteinfamilies.nf
@@ -98,11 +98,11 @@ workflow PROTEINFAMILIES {
     ch_versions = ch_versions.mix( REMOVE_REDUNDANCY.out.versions )
 
     // Post-processing
-    ch_full_msa = REMOVE_REDUNDANCY.out.full_msa
+    ch_fasta = REMOVE_REDUNDANCY.out.fasta
         .map { meta, aln -> [ [id: meta.id], aln ] }
         .groupTuple(by: 0)
 
-    EXTRACT_FAMILY_REPS( ch_full_msa )
+    EXTRACT_FAMILY_REPS( ch_fasta )
     ch_versions = ch_versions.mix( EXTRACT_FAMILY_REPS.out.versions )
     ch_family_reps = ch_family_reps.mix( EXTRACT_FAMILY_REPS.out.map )
 


### PR DESCRIPTION
`EXTRACT_FAMILY_REPS` thorough update.
Changed input from stockholm format and seqio library, to manual, faster parsing of fasta files.
Parallelized execution giving the module a `process_high` tag to dramatically cut down execution time for large scale runs.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/proteinfamilies/tree/main/.github/CONTRIBUTING.md)
- [x] If necessary, also make a PR on the nf-core/proteinfamilies _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
