### PR TITLE
extract_family_reps -appending all sequences in one- bug fixed

### DIFF
--- a/bin/extract_family_reps.py
+++ b/bin/extract_family_reps.py
@@ -65,23 +65,22 @@ def extract_data(filepath):
     header = None
     seq_lines = []
     size = 0
-    collecting = False
-    collected = False
+    collecting = True  # collect sequence until second header
 
     with open_func(filepath, "rt") as f:
         for line in f:
             line = line.strip()
             if not line:
                 continue
+
             if line.startswith(">"):
                 size += 1
-                if not collected:
-                    header = line[1:].split()[0]  # first header only
-                    collecting = True
-                else:
-                    collecting = False  # stop collecting sequence after first one
-                    collected = True
-            elif collecting:
+                if header is None:
+                    header = line[1:].split()[0]
+                elif collecting:
+                    # we’ve seen second header → stop collecting
+                    collecting = False
+            elif collecting and header is not None:
                 seq_lines.append(line)
 
     sequence = "".join(seq_lines).replace("-", "").replace(".", "").upper() if seq_lines else None

--- a/modules/local/extract_family_reps/test/main.nf.test
+++ b/modules/local/extract_family_reps/test/main.nf.test
@@ -24,10 +24,8 @@ nextflow_process {
             assertAll(
                 { assert process.success },
                 { assert snapshot(
-                    file(process.out.fasta[0][1]).name,
-                    path(process.out.fasta[0][1]).readLines().size(),
-                    file(process.out.map[0][1]).name,
-                    path(process.out.map[0][1]).readLines().size(),
+                    process.out.fasta,
+                    process.out.map,
                     process.out.versions.collect { path(it).yaml }
                     ).match()}
             )

--- a/modules/local/extract_family_reps/test/main.nf.test.snap
+++ b/modules/local/extract_family_reps/test/main.nf.test.snap
@@ -1,24 +1,4 @@
 {
-    "proteinfamilies - faa": {
-        "content": [
-            "extract_family_reps_reps.faa",
-            4,
-            "extract_family_reps_meta_mqc.csv",
-            8,
-            [
-                {
-                    "EXTRACT_FAMILY_REPS": {
-                        "python": "3.13.1"
-                    }
-                }
-            ]
-        ],
-        "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.6"
-        },
-        "timestamp": "2025-07-29T11:25:17.775635822"
-    },
     "proteinfamilies - faa - stub": {
         "content": [
             {
@@ -67,5 +47,37 @@
             "nextflow": "25.04.6"
         },
         "timestamp": "2025-07-29T11:25:31.692612332"
+    },
+    "proteinfamilies - faa": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "extract_family_reps"
+                    },
+                    "extract_family_reps_reps.faa:md5,5030c8c880e49f3abcdd90e5d8ffa1bf"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "extract_family_reps"
+                    },
+                    "extract_family_reps_meta_mqc.csv:md5,6b35848701c69871a9b9030f42f32a5b"
+                ]
+            ],
+            [
+                {
+                    "EXTRACT_FAMILY_REPS": {
+                        "python": "3.13.1"
+                    }
+                }
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-09-22T14:33:35.369690879"
     }
 }


### PR DESCRIPTION
Fixed a major bug where all fasta sequences were pasted into the cluster representative one

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/proteinfamilies/tree/main/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/proteinfamilies _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
