### PR TITLE
minor bug fix for reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Changed`
 
+- [#151](https://github.com/nf-core/proteinfamilies/pull/151)
+  - Removed an always-truthy if condition. (by @vagkaratzas)
+  - Moved a wrongly placed `.first()` to now properly report all sample representative sequences on the MultiQC report. (by @vagkaratzas)
 - [#150](https://github.com/nf-core/proteinfamilies/pull/150) - Pipeline logos and workflow maps updated. (by @vagkaratzas)
 - [#149](https://github.com/nf-core/proteinfamilies/pull/149) - Updated the nf-core/proteinfamilies article citation to the GigaScience publication. (by @vagkaratzas)
 - [#147](https://github.com/nf-core/proteinfamilies/pull/147) - Modules, subworkflows and pipeline code updates to fix linting warnings and errors. (by @vagkaratzas)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Changed`
 
-- [#151](https://github.com/nf-core/proteinfamilies/pull/151)
+- [#152](https://github.com/nf-core/proteinfamilies/pull/152)
   - Removed an always-truthy if condition. (by @vagkaratzas)
   - Moved a wrongly placed `.first()` to now properly report all sample representative sequences on the MultiQC report. (by @vagkaratzas)
 - [#150](https://github.com/nf-core/proteinfamilies/pull/150) - Pipeline logos and workflow maps updated. (by @vagkaratzas)

--- a/workflows/proteinfamilies.nf
+++ b/workflows/proteinfamilies.nf
@@ -75,21 +75,19 @@ workflow PROTEINFAMILIES {
     ch_samplesheet_for_update = ch_branch_result.to_update
 
     // Updating existing families
-    if (ch_branch_result.to_update) {
-        UPDATE_FAMILIES (
-            ch_samplesheet_for_update,
-            params.hmmsearch_query_length_threshold,
-            params.skip_sequence_redundancy_removal,
-            params.clustering_tool,
-            params.alignment_tool,
-            params.skip_msa_trimming,
-            params.clipkit_out_format
-        )
-        ch_versions = ch_versions.mix( UPDATE_FAMILIES.out.versions )
+    UPDATE_FAMILIES (
+        ch_samplesheet_for_update,
+        params.hmmsearch_query_length_threshold,
+        params.skip_sequence_redundancy_removal,
+        params.clustering_tool,
+        params.alignment_tool,
+        params.skip_msa_trimming,
+        params.clipkit_out_format
+    )
+    ch_versions = ch_versions.mix( UPDATE_FAMILIES.out.versions )
 
-        ch_family_reps = ch_family_reps.mix( UPDATE_FAMILIES.out.updated_family_reps )
-        ch_samplesheet_for_create = ch_samplesheet_for_create.mix( UPDATE_FAMILIES.out.no_hit_seqs )
-    }
+    ch_family_reps = ch_family_reps.mix( UPDATE_FAMILIES.out.updated_family_reps )
+    ch_samplesheet_for_create = ch_samplesheet_for_create.mix( UPDATE_FAMILIES.out.no_hit_seqs )
 
     // Creating new families
     // Clustering
@@ -164,8 +162,8 @@ workflow PROTEINFAMILIES {
     ch_versions = ch_versions.mix( EXTRACT_FAMILY_MEMBERS.out.versions.first() )
 
     EXTRACT_FAMILY_REPS( ch_fasta )
-    ch_versions = ch_versions.mix( EXTRACT_FAMILY_REPS.out.versions )
-    ch_family_reps = ch_family_reps.mix( EXTRACT_FAMILY_REPS.out.map.first() )
+    ch_versions = ch_versions.mix( EXTRACT_FAMILY_REPS.out.versions.first() )
+    ch_family_reps = ch_family_reps.mix( EXTRACT_FAMILY_REPS.out.map )
 
     //
     // Collate and save software versions


### PR DESCRIPTION
 Valid suggestions by seqera-cli-agent fixed on `proteinfamilies.nf`:
```
1. No-op if guard (line ~78) — if (ch_branch_result.to_update) does nothing. Channel objects are always truthy in Groovy. Remove it.
2. Suspicious .first() (line ~168) — If EXTRACT_FAMILY_REPS.out.map emits multiple items, .first() silently drops all but one.
```
## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/proteinfamilies/tree/main/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/proteinfamilies _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
