### PR TITLE
typo fixes

### DIFF
--- a/.nf-core.yml
+++ b/.nf-core.yml
@@ -2,8 +2,6 @@ lint:
   files_exist:
     - conf/igenomes.config
     - conf/igenomes_ignored.config
-    - conf/igenomes.config
-    - conf/igenomes_ignored.config
   files_unchanged:
     - .github/PULL_REQUEST_TEMPLATE.md
     - docs/images/nf-core-proteinfamilies_logo_light.png

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Changed`
 
+- [#153](https://github.com/nf-core/proteinfamilies/pull/153) - Typo fixes and unused boilerplate removal. (by @vagkaratzas)
 - [#152](https://github.com/nf-core/proteinfamilies/pull/152)
   - Removed an always-truthy if condition. (by @vagkaratzas)
   - Moved a wrongly placed `.first()` to now properly report all sample representative sequences on the MultiQC report. (by @vagkaratzas)

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -196,7 +196,7 @@ process {
         ]
     }
 
-    withName: '.*:UPDATE_FAMILIES_CLUSTERING:MMSEQS_FASTA_CLUSTER:MMSEQS_CLUSTER' {
+    withName: '.*:UPDATE_FAMILIES:MMSEQS_FASTA_CLUSTER:MMSEQS_CLUSTER' {
         ext.prefix = { "${meta.family}" }
         tag = { "${meta.family}_${meta.id}" }
         ext.args = [

--- a/conf/test_minimal.config
+++ b/conf/test_minimal.config
@@ -19,7 +19,7 @@ process {
 }
 
 params {
-    config_profile_name        = 'Minmal test profile'
+    config_profile_name        = 'Minimal test profile'
     config_profile_description = 'Minimal test dataset to check pipeline function (no MSA clipping, no redundancy checking, no update)'
 
     // Input data

--- a/subworkflows/local/utils_nfcore_proteinfamilies_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_proteinfamilies_pipeline/main.nf
@@ -159,20 +159,6 @@ workflow PIPELINE_COMPLETION {
 */
 
 //
-// Validate channels from input samplesheet
-//
-def validateInputSamplesheet(input) {
-    def (metas, fastqs) = input[1..2]
-
-    // Check that multiple runs of the same sample are of the same datatype i.e. single-end / paired-end
-    def endedness_ok = metas.collect{ meta -> meta.single_end }.unique().size == 1
-    if (!endedness_ok) {
-        error("Please check input samplesheet -> Multiple runs of a sample must be of the same datatype i.e. single-end or paired-end: ${metas[0].id}")
-    }
-
-    return [ metas[0], fastqs ]
-}
-//
 // Generate methods description for MultiQC
 //
 def toolCitationText() {
@@ -187,7 +173,7 @@ def toolCitationText() {
 
     def alignment_text = [
         "Multiple Sequence Alignment (MSA) was performed with ",
-        params.alignment_tool == 'famsa' ? "FAMSA (Deorowicz et al. 2026)." : "",
+        params.alignment_tool == 'famsa' ? "FAMSA (Deorowicz et al. 2016)." : "",
         params.alignment_tool == 'mafft' ? "mafft (Katoh et al. 2013)." : ""
     ].join(' ').trim()
 


### PR DESCRIPTION
- Wrong FAMSA citation year fixed — "Deorowicz et al. 2026" should be 2016 in utils_nfcore_proteinfamilies_pipeline/main.nf:190
- Stale process selector — UPDATE_FAMILIES_CLUSTERING in conf/modules.config:199 never matched any process, because was renamed)
- Dead boilerplate — validateInputSamplesheet (main.nf:164-174) is copy-pasted RNA-seq code that is never called --removed
- Typo: 'Minmal test profile' in conf/test_minimal.config:22 fixed
- Duplicate entries in .nf-core.yml removed

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/proteinfamilies/tree/main/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/proteinfamilies _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
