### PR TITLE
Update families/fasta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## v2.3.0dev - [date]
 
+### `Added`
+
+- Added optional save parameters for `update_families` mode: `--save_update_families_fasta`, `--save_update_families_non_redundant_fasta`, and `--save_update_families_clipped_fasta` to save FASTA files (with gaps removed) from updated family MSAs at various stages of the subworkflow (`update_families/fasta/from_msa/`, `update_families/fasta/from_clipped_msa/`, and `update_families/fasta/non_redundant_sequences/` respectively).
+
 ### `Changed`
 
+- [#154](https://github.com/nf-core/proteinfamilies/pull/154) - Moved `update_families` non-redundant sequence FASTA output from `mmseqs/update_families/non_redundant_sequences/` to `update_families/fasta/non_redundant_sequences/` (now controlled by `--save_update_families_non_redundant_fasta`).
 - [#153](https://github.com/nf-core/proteinfamilies/pull/153) - Typo fixes and unused boilerplate removal. (by @vagkaratzas)
 - [#152](https://github.com/nf-core/proteinfamilies/pull/152)
   - Removed an always-truthy if condition. (by @vagkaratzas)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added`
 
-- Added optional save parameters for `update_families` mode: `--save_update_families_fasta`, `--save_update_families_non_redundant_fasta`, and `--save_update_families_clipped_fasta` to save FASTA files (with gaps removed) from updated family MSAs at various stages of the subworkflow (`update_families/fasta/from_msa/`, `update_families/fasta/from_clipped_msa/`, and `update_families/fasta/non_redundant_sequences/` respectively).
+- [#154](https://github.com/nf-core/proteinfamilies/pull/154) - Added optional save parameters for `update_families` mode: `--save_update_families_pre_clipped_fasta`, and `--save_update_families_clipped_fasta` (with gaps removed) to save FASTA files from updated family MSAs at various stages of the subworkflow (`update_families/fasta/pre_clipped/`, `update_families/fasta/pre_clipped_non_redundant_sequences/`, and `update_families/fasta/post_clipped/`). (by @eparisis) (Hackathon 2026)
 
 ### `Changed`
 
-- [#154](https://github.com/nf-core/proteinfamilies/pull/154) - Moved `update_families` non-redundant sequence FASTA output from `mmseqs/update_families/non_redundant_sequences/` to `update_families/fasta/non_redundant_sequences/` (now controlled by `--save_update_families_non_redundant_fasta`).
+- [#154](https://github.com/nf-core/proteinfamilies/pull/154) - Moved `update_families` non-redundant sequence FASTA output from `mmseqs/update_families/non_redundant_sequences/` to `update_families/fasta/pre_clipped_non_redundant_sequences/${meta.id}/` (now controlled by `--save_update_families_pre_clipped_fasta`). (by @eparisis) (Hackathon 2026)
 - [#153](https://github.com/nf-core/proteinfamilies/pull/153) - Typo fixes and unused boilerplate removal. (by @vagkaratzas)
 - [#152](https://github.com/nf-core/proteinfamilies/pull/152)
   - Removed an always-truthy if condition. (by @vagkaratzas)

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -670,9 +670,9 @@ process {
         ext.prefix = { "${meta.family}" }
         tag = { "${meta.id}_${meta.family}" }
         publishDir = [
-            path: { "${params.outdir}/update_families/fasta/non_redundant_sequences/${meta.id}/" },
+            path: { "${params.outdir}/update_families/fasta/pre_clipped_non_redundant_sequences/${meta.id}/" },
             mode: params.publish_dir_mode,
-            enabled: params.save_update_families_non_redundant_fasta,
+            enabled: params.save_update_families_pre_clipped_fasta,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
@@ -682,9 +682,9 @@ process {
         ext.prefix = { "${meta.family}" }
         tag = { "${meta.id}_${meta.family}" }
         publishDir = [
-            path: { "${params.outdir}/update_families/fasta/from_msa/${meta.id}/" },
+            path: { "${params.outdir}/update_families/fasta/pre_clipped/${meta.id}/" },
             mode: params.publish_dir_mode,
-            enabled: params.save_update_families_fasta,
+            enabled: params.save_update_families_pre_clipped_fasta,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename.replaceAll(/\.\w+$/, '.faa') }
         ]
     }
@@ -694,7 +694,7 @@ process {
         ext.prefix = { "${meta.family}" }
         tag = { "${meta.id}_${meta.family}" }
         publishDir = [
-            path: { "${params.outdir}/update_families/fasta/from_clipped_msa/${meta.id}/" },
+            path: { "${params.outdir}/update_families/fasta/post_clipped/${meta.id}/" },
             mode: params.publish_dir_mode,
             enabled: params.save_update_families_clipped_fasta,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename.replaceAll(/\.\w+$/, '.faa') }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -670,10 +670,34 @@ process {
         ext.prefix = { "${meta.family}" }
         tag = { "${meta.family}_${meta.id}" }
         publishDir = [
-            path: { "${params.outdir}/update_families/non_redundant_sequences/${meta.id}/" },
+            path: { "${params.outdir}/update_families/fasta/non_redundant_sequences/${meta.id}/" },
             mode: params.publish_dir_mode,
-            enabled: false,
+            enabled: params.save_update_families_non_redundant_fasta,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+    withName: '.*:UPDATE_FAMILIES:SEQKIT_SEQ_MSA_TO_FASTA' {
+        ext.args = "--remove-gaps"
+        ext.prefix = { "${meta.family}" }
+        tag = { "${meta.family}_${meta.id}" }
+        publishDir = [
+            path: { "${params.outdir}/update_families/fasta/from_msa/${meta.id}/" },
+            mode: params.publish_dir_mode,
+            enabled: params.save_update_families_fasta,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename.replaceAll(/\.\w+$/, '.faa') }
+        ]
+    }
+
+    withName: '.*:UPDATE_FAMILIES:SEQKIT_SEQ_CLIPPED_MSA_TO_FASTA' {
+        ext.args = "--remove-gaps"
+        ext.prefix = { "${meta.family}" }
+        tag = { "${meta.family}_${meta.id}" }
+        publishDir = [
+            path: { "${params.outdir}/update_families/fasta/from_clipped_msa/${meta.id}/" },
+            mode: params.publish_dir_mode,
+            enabled: params.save_update_families_fasta,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename.replaceAll(/\.\w+$/, '.faa') }
         ]
     }
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -696,7 +696,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/update_families/fasta/from_clipped_msa/${meta.id}/" },
             mode: params.publish_dir_mode,
-            enabled: params.save_update_families_fasta,
+            enabled: params.save_update_families_clipped_fasta,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename.replaceAll(/\.\w+$/, '.faa') }
         ]
     }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -141,10 +141,10 @@ process {
 
     withName: '.*:UPDATE_FAMILIES:SEQKIT_SEQ' {
         ext.args = "--remove-gaps"
-        ext.prefix = { "${meta.id}_${meta.family}" }
+        ext.prefix = { "${meta.family}" }
         tag = { "${meta.id}_${meta.family}" }
         publishDir = [
-            path: { "${params.outdir}/seqkit/" },
+            path: { "${params.outdir}/seqkit/${meta.id}/" },
             mode: params.publish_dir_mode,
             enabled: false,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
@@ -162,9 +162,9 @@ process {
 
     withName: '.*:UPDATE_FAMILIES:MMSEQS_FASTA_CLUSTER:MMSEQS_CREATEDB' {
         ext.prefix = { "${meta.family}" }
-        tag = { "${meta.family}_${meta.id}" }
+        tag = { "${meta.id}_${meta.family}" }
         publishDir = [
-            path: { "${params.outdir}/mmseqs/update_families/mmseqs_createdb/" },
+            path: { "${params.outdir}/mmseqs/update_families/mmseqs_createdb/${meta.id}/" },
             mode: params.publish_dir_mode,
             enabled: false,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
@@ -198,14 +198,14 @@ process {
 
     withName: '.*:UPDATE_FAMILIES:MMSEQS_FASTA_CLUSTER:MMSEQS_CLUSTER' {
         ext.prefix = { "${meta.family}" }
-        tag = { "${meta.family}_${meta.id}" }
+        tag = { "${meta.id}_${meta.family}" }
         ext.args = [
             "--min-seq-id ${params.cluster_seq_identity_for_redundancy}",
             "-c ${params.cluster_coverage_for_redundancy}",
             "--cov-mode ${params.cluster_cov_mode_for_redundancy}",
         ].join(' ').trim()
         publishDir = [
-            path: { "${params.outdir}/mmseqs/update_families/mmseqs_cluster/" },
+            path: { "${params.outdir}/mmseqs/update_families/mmseqs_cluster/${meta.id}/" },
             mode: params.publish_dir_mode,
             enabled: false,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
@@ -244,14 +244,14 @@ process {
 
     withName: '.*:UPDATE_FAMILIES:MMSEQS_FASTA_CLUSTER:MMSEQS_LINCLUST' {
         ext.prefix = { "${meta.family}" }
-        tag = { "${meta.family}_${meta.id}" }
+        tag = { "${meta.id}_${meta.family}" }
         ext.args = [
             "--min-seq-id ${params.cluster_seq_identity_for_redundancy}",
             "-c ${params.cluster_coverage_for_redundancy}",
             "--cov-mode ${params.cluster_cov_mode_for_redundancy}",
         ].join(' ').trim()
         publishDir = [
-            path: { "${params.outdir}/mmseqs/update_families/mmseqs_linclust/" },
+            path: { "${params.outdir}/mmseqs/update_families/mmseqs_linclust/${meta.id}/" },
             mode: params.publish_dir_mode,
             enabled: false,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
@@ -284,7 +284,7 @@ process {
 
     withName: '.*:UPDATE_FAMILIES:MMSEQS_FASTA_CLUSTER:MMSEQS_CREATETSV' {
         ext.prefix = { "${meta.family}" }
-        tag = { "${meta.family}_${meta.id}" }
+        tag = { "${meta.id}_${meta.family}" }
         publishDir = [
             path: { "${params.outdir}/mmseqs/update_families/mmseqs_createtsv/${meta.id}/" },
             mode: params.publish_dir_mode,
@@ -341,7 +341,7 @@ process {
 
     withName: '.*:UPDATE_FAMILIES:ALIGN_SEQUENCES:FAMSA_ALIGN' {
         ext.prefix = { "${meta.family}" }
-        tag = { "${meta.family}_${meta.id}" }
+        tag = { "${meta.id}_${meta.family}" }
         publishDir = [
             path: { "${params.outdir}/update_families/full_msa/famsa_align/${meta.id}/" },
             mode: params.publish_dir_mode,
@@ -435,7 +435,7 @@ process {
             params.trim_ends_only ? "--ends_only" : ''
         ].join(' ').trim()
         ext.prefix = { "${meta.family}" }
-        tag = { "${meta.family}_${meta.id}" }
+        tag = { "${meta.id}_${meta.family}" }
         publishDir = [
             path: { "${params.outdir}/update_families/full_msa/clipkit/${meta.id}/" },
             mode: params.publish_dir_mode,
@@ -461,18 +461,18 @@ process {
         publishDir = [
             path: { "${params.outdir}/remove_redundancy/merge_families/hmm/raw/${meta.id}/" },
             mode: params.publish_dir_mode,
-            pattern: "*.{hmm.gz}",
+            pattern: "*.hmm.gz",
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
 
     withName: '.*:UPDATE_FAMILIES:HMMER_HMMBUILD' {
         ext.prefix = { "${meta.family}" }
-        tag = { "${meta.family}_${meta.id}" }
+        tag = { "${meta.id}_${meta.family}" }
         publishDir = [
             path: { "${params.outdir}/update_families/hmm/${meta.id}/" },
             mode: params.publish_dir_mode,
-            pattern: "*.{hmm.gz}",
+            pattern: "*.hmm.gz",
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
@@ -668,7 +668,7 @@ process {
 
     withName: '.*:UPDATE_FAMILIES:REMOVE_REDUNDANT_SEQS' {
         ext.prefix = { "${meta.family}" }
-        tag = { "${meta.family}_${meta.id}" }
+        tag = { "${meta.id}_${meta.family}" }
         publishDir = [
             path: { "${params.outdir}/update_families/fasta/non_redundant_sequences/${meta.id}/" },
             mode: params.publish_dir_mode,
@@ -679,8 +679,8 @@ process {
 
     withName: '.*:UPDATE_FAMILIES:SEQKIT_SEQ_MSA_TO_FASTA' {
         ext.args = "--remove-gaps"
-        ext.prefix = { "${meta.id}_${meta.family}" }
-        tag = { "${meta.family}_${meta.id}" }
+        ext.prefix = { "${meta.family}" }
+        tag = { "${meta.id}_${meta.family}" }
         publishDir = [
             path: { "${params.outdir}/update_families/fasta/from_msa/${meta.id}/" },
             mode: params.publish_dir_mode,
@@ -691,8 +691,8 @@ process {
 
     withName: '.*:UPDATE_FAMILIES:SEQKIT_SEQ_CLIPPED_MSA_TO_FASTA' {
         ext.args = "--remove-gaps"
-        ext.prefix = { "${meta.id}_${meta.family}" }
-        tag = { "${meta.family}_${meta.id}" }
+        ext.prefix = { "${meta.family}" }
+        tag = { "${meta.id}_${meta.family}" }
         publishDir = [
             path: { "${params.outdir}/update_families/fasta/from_clipped_msa/${meta.id}/" },
             mode: params.publish_dir_mode,

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -679,7 +679,7 @@ process {
 
     withName: '.*:UPDATE_FAMILIES:SEQKIT_SEQ_MSA_TO_FASTA' {
         ext.args = "--remove-gaps"
-        ext.prefix = { "${meta.family}" }
+        ext.prefix = { "${meta.id}_${meta.family}" }
         tag = { "${meta.family}_${meta.id}" }
         publishDir = [
             path: { "${params.outdir}/update_families/fasta/from_msa/${meta.id}/" },
@@ -691,7 +691,7 @@ process {
 
     withName: '.*:UPDATE_FAMILIES:SEQKIT_SEQ_CLIPPED_MSA_TO_FASTA' {
         ext.args = "--remove-gaps"
-        ext.prefix = { "${meta.family}" }
+        ext.prefix = { "${meta.id}_${meta.family}" }
         tag = { "${meta.family}_${meta.id}" }
         publishDir = [
             path: { "${params.outdir}/update_families/fasta/from_clipped_msa/${meta.id}/" },

--- a/conf/test.config
+++ b/conf/test.config
@@ -64,7 +64,7 @@ process {
         time   = { 2.m    * task.attempt }
     }
     withName: 'NFCORE_PROTEINFAMILIES:PROTEINFAMILIES:MMSEQS_FASTA_CLUSTER:MMSEQS_CREATETSV' {
-        memory = { 6.MB * task.attempt }
+        memory = { 3.GB * task.attempt }
         time   = { 3.m  * task.attempt }
     }
     withName: 'NFCORE_PROTEINFAMILIES:PROTEINFAMILIES:CALCULATE_CLUSTER_DISTRIBUTION' {

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -122,7 +122,7 @@ process {
         time   = { 5.m  * task.attempt }
     }
     withName: 'NFCORE_PROTEINFAMILIES:PROTEINFAMILIES:MMSEQS_FASTA_CLUSTER:MMSEQS_CREATETSV' {
-        memory = { 1.GB * task.attempt }
+        memory = { 3.GB * task.attempt }
         time   = { 5.m  * task.attempt }
     }
     withName: 'NFCORE_PROTEINFAMILIES:PROTEINFAMILIES:CALCULATE_CLUSTER_DISTRIBUTION' {

--- a/conf/test_update.config
+++ b/conf/test_update.config
@@ -29,6 +29,5 @@ params {
     cluster_seq_identity                     = 0.5
     cluster_coverage                         = 0.9
     cluster_size_threshold                   = 5
-    save_update_families_fasta               = true
-    save_update_families_non_redundant_fasta = true
+    save_update_families_pre_clipped_fasta   = true
 }

--- a/conf/test_update.config
+++ b/conf/test_update.config
@@ -25,8 +25,10 @@ params {
     // Input data
     input                         = params.pipelines_testdata_base_path + 'samplesheets/samplesheet_update.csv'
     // Clustering
-    clustering_tool               = 'linclust'
-    cluster_seq_identity          = 0.5
-    cluster_coverage              = 0.9
-    cluster_size_threshold        = 5
+    clustering_tool                          = 'linclust'
+    cluster_seq_identity                     = 0.5
+    cluster_coverage                         = 0.9
+    cluster_size_threshold                   = 5
+    save_update_families_fasta               = true
+    save_update_families_non_redundant_fasta = true
 }

--- a/docs/output.md
+++ b/docs/output.md
@@ -472,14 +472,19 @@ in the `update_families/hmmer/hmmbuild` folder, from the respective new MSAs.
   - `<samplename>_<family_id>.fastq`: (optional) fasta formatted family sequences from full MSA with gaps removed
 - `update_families/`
   - `fasta/`
-    - `<samplename>_<family_id>.fastq`: (optional) concatenated family fasta with newly recruited sequences
+    - `from_msa/`
+      - `<samplename>/`
+        - `<samplename>_<family_id>.faa`: (optional) FASTA files with gaps removed from aligned family MSAs. Can be turned on with `--save_update_families_fasta`
+    - `from_clipped_msa/`
+      - `<samplename>/`
+        - `<samplename>_<family_id>.faa`: (optional) FASTA files with gaps removed from ClipKIT-trimmed family MSAs. Can be turned on with `--save_update_families_clipped_fasta` (default: `true`)
 
 </details>
 
 The `seqkit` module is mainly used during the `update_families` mode
 to extract sequences from family MSA, into intermediate fasta files (`seqkit` output folder).
-The intermediate `update_families/fasta` folder contains the aggregation of existing family sequences along with their newly matching ones,
-that will together produce the updated family MSA.
+The `update_families/fasta` folder contains optional FASTA outputs: `from_msa` holds gap-removed sequences from aligned MSAs (before clipping),
+and `from_clipped_msa` holds gap-removed sequences from ClipKIT-trimmed MSAs.
 
 [SeqKit](https://github.com/shenwei356/seqkit) is a cross-platform and ultrafast toolkit for FASTA/Q file manipulation.
 
@@ -502,15 +507,18 @@ that will together produce the updated family MSA.
     - `mmseqs_cluster/`
       - `<family_id>/`
         - `*`: (optional) mmseqs format clustered db
+- `update_families/`
+  - `fasta/`
     - `non_redundant_sequences/`
       - `<samplename>/`
-        - `<samplename>_reps.faa`: (optional) fasta file of all family representative sequences (one sequence per family)
+        - `<family_id>.faa`: (optional) FASTA files with non-redundant sequence sets per family. Can be turned on with `--save_update_families_non_redundant_fasta`
 
 </details>
 
 Similarly to the in-family sequence redundancy removal mechanism, the mmseqs suite is used to strictly cluster
 existing family sequences along newly recruited ones, keeping a non redundant set.
-The new family representative sequences can now be found in the intermediate `mmseqs/non_redundant_sequences` folder.
+When `--save_update_families_non_redundant_fasta` is set to `true`, the non-redundant family FASTA files
+are saved to `update_families/fasta/non_redundant_sequences/`.
 
 [MMseqs2](https://github.com/soedinglab/MMseqs2) clusters amino acid fasta files via either the 'cluster' or the 'linclust' algorithms.
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -473,19 +473,22 @@ in the `update_families/hmmer/hmmbuild` folder, from the respective new MSAs.
     - `<family_id>.fastq`: (optional) fasta formatted family sequences from full MSA with gaps removed
 - `update_families/`
   - `fasta/`
-    - `from_msa/`
+    - `pre_clipped_non_redundant_sequences/`
       - `<samplename>/`
-        - `<family_id>.faa`: (optional) FASTA files with gaps removed from aligned family MSAs. Can be turned on with `--save_update_families_fasta`
-    - `from_clipped_msa/`
+        - `<family_id>.faa`: (optional) FASTA files before gap removal from family MSAs. Can be turned on with `--save_update_families_pre_clipped_fasta`, when `skip_sequence_redundancy_removal` is false
+    - `pre_clipped/`
       - `<samplename>/`
-        - `<family_id>.faa`: (optional) FASTA files with gaps removed from ClipKIT-trimmed family MSAs. Can be turned on with `--save_update_families_clipped_fasta` (default: `true`)
+        - `<family_id>.faa`: (optional) FASTA files before gap removal from family MSAs. Can be turned on with `--save_update_families_pre_clipped_fasta`, but `skip_sequence_redundancy_removal` also needs to be true
+    - `post_clipped/`
+      - `<samplename>/`
+        - `<family_id>.faa`: (optional) FASTA files with gaps removed from family MSAs. Can be turned on with `--save_update_families_clipped_fasta` (default: `true`)
 
 </details>
 
 The `seqkit` module is mainly used during the `update_families` mode
 to extract sequences from family MSA, into intermediate fasta files (`seqkit` output folder).
-The `update_families/fasta` folder contains optional FASTA outputs: `from_msa` holds gap-removed sequences from aligned MSAs (before clipping),
-and `from_clipped_msa` holds gap-removed sequences from ClipKIT-trimmed MSAs.
+The `update_families/fasta` folder contains optional FASTA outputs: `pre_clipped_non_redundant_sequences`, if sequence redundancy within families was removed, `pre_clipped` holds gap-removed sequences from aligned MSAs (before clipping, if sequence redundancy was not removed),
+and `post_clipped` holds gappy-column-removed final sequences from clipped MSAs.
 
 [SeqKit](https://github.com/shenwei356/seqkit) is a cross-platform and ultrafast toolkit for FASTA/Q file manipulation.
 
@@ -511,18 +514,11 @@ and `from_clipped_msa` holds gap-removed sequences from ClipKIT-trimmed MSAs.
       - `<samplename>/`
         - `<family_id>/`
           - `*`: (optional) mmseqs format clustered db
-- `update_families/`
-  - `fasta/`
-    - `non_redundant_sequences/`
-      - `<samplename>/`
-        - `<family_id>.faa`: (optional) FASTA files with non-redundant sequence sets per family. Can be turned on with `--save_update_families_non_redundant_fasta`
 
 </details>
 
 Similarly to the in-family sequence redundancy removal mechanism, the mmseqs suite is used to strictly cluster
 existing family sequences along newly recruited ones, keeping a non redundant set.
-When `--save_update_families_non_redundant_fasta` is set to `true`, the non-redundant family FASTA files
-are saved to `update_families/fasta/non_redundant_sequences/`.
 
 [MMseqs2](https://github.com/soedinglab/MMseqs2) clusters amino acid fasta files via either the 'cluster' or the 'linclust' algorithms.
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -469,15 +469,16 @@ in the `update_families/hmmer/hmmbuild` folder, from the respective new MSAs.
 <summary>Output files</summary>
 
 - `seqkit/`
-  - `<samplename>_<family_id>.fastq`: (optional) fasta formatted family sequences from full MSA with gaps removed
+  - `<samplename>/`
+    - `<family_id>.fastq`: (optional) fasta formatted family sequences from full MSA with gaps removed
 - `update_families/`
   - `fasta/`
     - `from_msa/`
       - `<samplename>/`
-        - `<samplename>_<family_id>.faa`: (optional) FASTA files with gaps removed from aligned family MSAs. Can be turned on with `--save_update_families_fasta`
+        - `<family_id>.faa`: (optional) FASTA files with gaps removed from aligned family MSAs. Can be turned on with `--save_update_families_fasta`
     - `from_clipped_msa/`
       - `<samplename>/`
-        - `<samplename>_<family_id>.faa`: (optional) FASTA files with gaps removed from ClipKIT-trimmed family MSAs. Can be turned on with `--save_update_families_clipped_fasta` (default: `true`)
+        - `<family_id>.faa`: (optional) FASTA files with gaps removed from ClipKIT-trimmed family MSAs. Can be turned on with `--save_update_families_clipped_fasta` (default: `true`)
 
 </details>
 
@@ -499,14 +500,17 @@ and `from_clipped_msa` holds gap-removed sequences from ClipKIT-trimmed MSAs.
       - `<samplename>/`
         - `<family_id>.tsv`: tab-separated table containing 2 columns; the first one with the cluster representative sequences, and the second with the cluster members
     - `mmseqs_createdb/`
-      - `<family_id>/`
-        - `*`: (optional) mmseqs format db of fasta sequences
+      - `<samplename>/`
+        - `<family_id>/`
+          - `*`: (optional) mmseqs format db of fasta sequences
     - `mmseqs_linclust/`
-      - `<family_id>/`
-        - `*`: (optional) mmseqs format clustered db
+      - `<samplename>/`
+        - `<family_id>/`
+          - `*`: (optional) mmseqs format clustered db
     - `mmseqs_cluster/`
-      - `<family_id>/`
-        - `*`: (optional) mmseqs format clustered db
+      - `<samplename>/`
+        - `<family_id>/`
+          - `*`: (optional) mmseqs format clustered db
 - `update_families/`
   - `fasta/`
     - `non_redundant_sequences/`

--- a/nextflow.config
+++ b/nextflow.config
@@ -52,8 +52,9 @@ params {
     cluster_cov_mode_for_redundancy              = 0
     save_non_redundant_seqs_fasta                = true
     // Update families output
-    save_update_families_fasta                   = true
-    save_update_families_non_redundant_fasta     = true
+    save_update_families_fasta                   = false
+    save_update_families_non_redundant_fasta     = false
+    save_update_families_clipped_fasta           = true
     // Phylogeny
     skip_phylogenetic_inference                  = true
     // Downstream samplesheets

--- a/nextflow.config
+++ b/nextflow.config
@@ -52,8 +52,7 @@ params {
     cluster_cov_mode_for_redundancy              = 0
     save_non_redundant_seqs_fasta                = true
     // Update families output
-    save_update_families_fasta                   = false
-    save_update_families_non_redundant_fasta     = false
+    save_update_families_pre_clipped_fasta       = false
     save_update_families_clipped_fasta           = true
     // Phylogeny
     skip_phylogenetic_inference                  = true

--- a/nextflow.config
+++ b/nextflow.config
@@ -51,6 +51,9 @@ params {
     cluster_coverage_for_redundancy              = 0.9
     cluster_cov_mode_for_redundancy              = 0
     save_non_redundant_seqs_fasta                = true
+    // Update families output
+    save_update_families_fasta                   = true
+    save_update_families_non_redundant_fasta     = true
     // Phylogeny
     skip_phylogenetic_inference                  = true
     // Downstream samplesheets

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -470,6 +470,11 @@
                     "default": 0,
                     "description": "mmseqs parameter for coverage mode: 0 for both, 1 for target and 2 for query sequence",
                     "help_text": "Defined by the number of aligned residue pairs divided by 0: the maximum of the length of query/centre and target/non-centre sequences, 1: the length of the target/non-centre sequence, 2: the length of the query/centre"
+                },
+                "save_non_redundant_seqs_fasta": {
+                    "type": "boolean",
+                    "description": "Save the final family fasta files with sequence redundancy removed",
+                    "help_text": "Specify to save the family fasta files with non-redundant sequence sets."
                 }
             }
         },

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -238,6 +238,25 @@
                 }
             }
         },
+        "update_params": {
+            "title": "Update mechanism parameters",
+            "type": "object",
+            "description": "Use these parameters to optionally save FASTA outputs during the update families mechanism.",
+            "properties": {
+                "save_update_families_pre_clipped_fasta": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Save intermediate FASTA files before clipping gappy ends (non-redundant --if `skip_sequence_redundancy_removal` is false-- or all --if `skip_sequence_redundancy_removal` is true--) in the update_families subworkflow",
+                    "help_text": "Specify to save the FASTA files before clipping gappy ends in the update_families path."
+                },
+                "save_update_families_clipped_fasta": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Save FASTA files derived from updated family MSAs (after re-alignment and clipping)",
+                    "help_text": "Specify to save FASTA files (with gaps removed) from MSAs produced during the update_families subworkflow."
+                }
+            }
+        },
         "clustering_params": {
             "title": "Clustering parameters",
             "type": "object",
@@ -451,29 +470,6 @@
                     "default": 0,
                     "description": "mmseqs parameter for coverage mode: 0 for both, 1 for target and 2 for query sequence",
                     "help_text": "Defined by the number of aligned residue pairs divided by 0: the maximum of the length of query/centre and target/non-centre sequences, 1: the length of the target/non-centre sequence, 2: the length of the query/centre"
-                },
-                "save_non_redundant_seqs_fasta": {
-                    "type": "boolean",
-                    "description": "Save the final family fasta files with sequence redundancy removed",
-                    "help_text": "Specify to save the family fasta files with non-redundant sequence sets."
-                },
-                "save_update_families_fasta": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Save FASTA files derived from updated family MSAs (after alignment and after clipping)",
-                    "help_text": "Specify to save FASTA files (with gaps removed) from MSAs produced during the update_families subworkflow."
-                },
-                "save_update_families_non_redundant_fasta": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Save non-redundant FASTA files after sequence redundancy removal in the update_families subworkflow",
-                    "help_text": "Specify to save the FASTA files after sequence-level redundancy removal in the update_families path."
-                },
-                "save_update_families_clipped_fasta": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Save FASTA files derived from updated family MSAs (after alignment and after clipping)",
-                    "help_text": "Specify to save FASTA files (with gaps removed) from MSAs produced during the update_families subworkflow."
                 }
             }
         },
@@ -525,6 +521,9 @@
         },
         {
             "$ref": "#/$defs/quality_check_params"
+        },
+        {
+            "$ref": "#/$defs/update_params"
         },
         {
             "$ref": "#/$defs/clustering_params"

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -459,13 +459,21 @@
                 },
                 "save_update_families_fasta": {
                     "type": "boolean",
+                    "default": false,
                     "description": "Save FASTA files derived from updated family MSAs (after alignment and after clipping)",
                     "help_text": "Specify to save FASTA files (with gaps removed) from MSAs produced during the update_families subworkflow."
                 },
                 "save_update_families_non_redundant_fasta": {
                     "type": "boolean",
+                    "default": false,
                     "description": "Save non-redundant FASTA files after sequence redundancy removal in the update_families subworkflow",
                     "help_text": "Specify to save the FASTA files after sequence-level redundancy removal in the update_families path."
+                },
+                "save_update_families_clipped_fasta": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Save FASTA files derived from updated family MSAs (after alignment and after clipping)",
+                    "help_text": "Specify to save FASTA files (with gaps removed) from MSAs produced during the update_families subworkflow."
                 }
             }
         },

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -456,6 +456,16 @@
                     "type": "boolean",
                     "description": "Save the final family fasta files with sequence redundancy removed",
                     "help_text": "Specify to save the family fasta files with non-redundant sequence sets."
+                },
+                "save_update_families_fasta": {
+                    "type": "boolean",
+                    "description": "Save FASTA files derived from updated family MSAs (after alignment and after clipping)",
+                    "help_text": "Specify to save FASTA files (with gaps removed) from MSAs produced during the update_families subworkflow."
+                },
+                "save_update_families_non_redundant_fasta": {
+                    "type": "boolean",
+                    "description": "Save non-redundant FASTA files after sequence redundancy removal in the update_families subworkflow",
+                    "help_text": "Specify to save the FASTA files after sequence-level redundancy removal in the update_families path."
                 }
             }
         },

--- a/subworkflows/local/update_families/main.nf
+++ b/subworkflows/local/update_families/main.nf
@@ -2,23 +2,23 @@
     UPDATE EXISTING FAMILIES HMM AND MSA
 */
 
-include { UNTAR as UNTAR_HMM            } from '../../../modules/nf-core/untar/main'
-include { UNTAR as UNTAR_MSA            } from '../../../modules/nf-core/untar/main'
-include { validateMatchingFolders       } from '../../../subworkflows/local/utils_nfcore_proteinfamilies_pipeline'
-include { FIND_CONCATENATE as CAT_HMM   } from '../../../modules/nf-core/find/concatenate/main'
-include { HMMER_HMMSEARCH               } from '../../../modules/nf-core/hmmer/hmmsearch/main'
-include { BRANCH_HITS_FASTA             } from '../../../modules/local/branch_hits_fasta'
+include { UNTAR as UNTAR_HMM                            } from '../../../modules/nf-core/untar/main'
+include { UNTAR as UNTAR_MSA                            } from '../../../modules/nf-core/untar/main'
+include { validateMatchingFolders                       } from '../../../subworkflows/local/utils_nfcore_proteinfamilies_pipeline'
+include { FIND_CONCATENATE as CAT_HMM                   } from '../../../modules/nf-core/find/concatenate/main'
+include { HMMER_HMMSEARCH                               } from '../../../modules/nf-core/hmmer/hmmsearch/main'
+include { BRANCH_HITS_FASTA                             } from '../../../modules/local/branch_hits_fasta'
 include { SEQKIT_SEQ                                    } from '../../../modules/nf-core/seqkit/seq/main'
 include { SEQKIT_SEQ as SEQKIT_SEQ_MSA_TO_FASTA         } from '../../../modules/nf-core/seqkit/seq/main'
 include { SEQKIT_SEQ as SEQKIT_SEQ_CLIPPED_MSA_TO_FASTA } from '../../../modules/nf-core/seqkit/seq/main'
-include { FIND_CONCATENATE as CAT_FASTA } from '../../../modules/nf-core/find/concatenate/main'
-include { MMSEQS_FASTA_CLUSTER          } from '../../../subworkflows/nf-core/mmseqs_fasta_cluster'
-include { REMOVE_REDUNDANT_SEQS         } from '../../../modules/local/remove_redundant_seqs/main'
-include { ALIGN_SEQUENCES               } from '../../../subworkflows/local/align_sequences'
-include { CLIPKIT                       } from '../../../modules/nf-core/clipkit/main'
-include { HMMER_HMMBUILD                } from '../../../modules/nf-core/hmmer/hmmbuild/main'
-include { EXTRACT_FAMILY_MEMBERS        } from '../../../modules/local/extract_family_members/main'
-include { EXTRACT_FAMILY_REPS           } from '../../../modules/local/extract_family_reps/main'
+include { FIND_CONCATENATE as CAT_FASTA                 } from '../../../modules/nf-core/find/concatenate/main'
+include { MMSEQS_FASTA_CLUSTER                          } from '../../../subworkflows/nf-core/mmseqs_fasta_cluster'
+include { REMOVE_REDUNDANT_SEQS                         } from '../../../modules/local/remove_redundant_seqs/main'
+include { ALIGN_SEQUENCES                               } from '../../../subworkflows/local/align_sequences'
+include { CLIPKIT                                       } from '../../../modules/nf-core/clipkit/main'
+include { HMMER_HMMBUILD                                } from '../../../modules/nf-core/hmmer/hmmbuild/main'
+include { EXTRACT_FAMILY_MEMBERS                        } from '../../../modules/local/extract_family_members/main'
+include { EXTRACT_FAMILY_REPS                           } from '../../../modules/local/extract_family_reps/main'
 
 workflow UPDATE_FAMILIES {
     take:

--- a/subworkflows/local/update_families/main.nf
+++ b/subworkflows/local/update_families/main.nf
@@ -22,13 +22,15 @@ include { EXTRACT_FAMILY_REPS                           } from '../../../modules
 
 workflow UPDATE_FAMILIES {
     take:
-    ch_samplesheet_for_update        // channel: [meta, sequences, existing_hmms_to_update, existing_msas_to_update]
-    hmmsearch_query_length_threshold // number [0.0, 1.0]
-    skip_sequence_redundancy_removal // boolean
-    clustering_tool                  // string ["linclust", "cluster"]
-    alignment_tool                   // string ["famsa", "mafft"]
-    skip_msa_trimming                // boolean
-    clipkit_out_format               // string (default: clipkit)
+    ch_samplesheet_for_update                   // channel: [meta, sequences, existing_hmms_to_update, existing_msas_to_update]
+    hmmsearch_query_length_threshold            // number [0.0, 1.0]
+    skip_sequence_redundancy_removal            // boolean
+    clustering_tool                             // string ["linclust", "cluster"]
+    alignment_tool                              // string ["famsa", "mafft"]
+    skip_msa_trimming                           // boolean
+    clipkit_out_format                          // string (default: clipkit)
+    save_update_families_fasta                  // boolean
+    save_update_families_clipped_fasta          // boolean
 
     main:
     ch_versions            = channel.empty()
@@ -121,8 +123,11 @@ workflow UPDATE_FAMILIES {
 
     ALIGN_SEQUENCES( ch_fasta, alignment_tool )
     ch_versions = ch_versions.mix( ALIGN_SEQUENCES.out.versions )
-    SEQKIT_SEQ_MSA_TO_FASTA( ALIGN_SEQUENCES.out.alignments )
-    ch_versions = ch_versions.mix( SEQKIT_SEQ_MSA_TO_FASTA.out.versions.first() )
+
+    if (save_update_families_fasta) {
+        SEQKIT_SEQ_MSA_TO_FASTA( ALIGN_SEQUENCES.out.alignments )
+        ch_versions = ch_versions.mix( SEQKIT_SEQ_MSA_TO_FASTA.out.versions.first() )
+    }
 
     ch_msa = ALIGN_SEQUENCES.out.alignments
 
@@ -131,8 +136,10 @@ workflow UPDATE_FAMILIES {
         ch_versions = ch_versions.mix( CLIPKIT.out.versions.first() )
         ch_msa = CLIPKIT.out.clipkit
 
-        SEQKIT_SEQ_CLIPPED_MSA_TO_FASTA( CLIPKIT.out.clipkit )
-        ch_versions = ch_versions.mix( SEQKIT_SEQ_CLIPPED_MSA_TO_FASTA.out.versions.first() )
+        if (save_update_families_clipped_fasta) {
+            SEQKIT_SEQ_CLIPPED_MSA_TO_FASTA( CLIPKIT.out.clipkit )
+            ch_versions = ch_versions.mix( SEQKIT_SEQ_CLIPPED_MSA_TO_FASTA.out.versions.first() )
+        }
     }
 
     HMMER_HMMBUILD( ch_msa, [] )

--- a/subworkflows/local/update_families/main.nf
+++ b/subworkflows/local/update_families/main.nf
@@ -8,7 +8,9 @@ include { validateMatchingFolders       } from '../../../subworkflows/local/util
 include { FIND_CONCATENATE as CAT_HMM   } from '../../../modules/nf-core/find/concatenate/main'
 include { HMMER_HMMSEARCH               } from '../../../modules/nf-core/hmmer/hmmsearch/main'
 include { BRANCH_HITS_FASTA             } from '../../../modules/local/branch_hits_fasta'
-include { SEQKIT_SEQ                    } from '../../../modules/nf-core/seqkit/seq/main'
+include { SEQKIT_SEQ                                    } from '../../../modules/nf-core/seqkit/seq/main'
+include { SEQKIT_SEQ as SEQKIT_SEQ_MSA_TO_FASTA         } from '../../../modules/nf-core/seqkit/seq/main'
+include { SEQKIT_SEQ as SEQKIT_SEQ_CLIPPED_MSA_TO_FASTA } from '../../../modules/nf-core/seqkit/seq/main'
 include { FIND_CONCATENATE as CAT_FASTA } from '../../../modules/nf-core/find/concatenate/main'
 include { MMSEQS_FASTA_CLUSTER          } from '../../../subworkflows/nf-core/mmseqs_fasta_cluster'
 include { REMOVE_REDUNDANT_SEQS         } from '../../../modules/local/remove_redundant_seqs/main'
@@ -119,12 +121,18 @@ workflow UPDATE_FAMILIES {
 
     ALIGN_SEQUENCES( ch_fasta, alignment_tool )
     ch_versions = ch_versions.mix( ALIGN_SEQUENCES.out.versions )
+    SEQKIT_SEQ_MSA_TO_FASTA( ALIGN_SEQUENCES.out.alignments )
+    ch_versions = ch_versions.mix( SEQKIT_SEQ_MSA_TO_FASTA.out.versions.first() )
+
     ch_msa = ALIGN_SEQUENCES.out.alignments
 
     if (!skip_msa_trimming) {
         CLIPKIT( ch_msa, clipkit_out_format )
         ch_versions = ch_versions.mix( CLIPKIT.out.versions.first() )
         ch_msa = CLIPKIT.out.clipkit
+
+        SEQKIT_SEQ_CLIPPED_MSA_TO_FASTA( CLIPKIT.out.clipkit )
+        ch_versions = ch_versions.mix( SEQKIT_SEQ_CLIPPED_MSA_TO_FASTA.out.versions.first() )
     }
 
     HMMER_HMMBUILD( ch_msa, [] )

--- a/subworkflows/local/update_families/main.nf
+++ b/subworkflows/local/update_families/main.nf
@@ -29,7 +29,7 @@ workflow UPDATE_FAMILIES {
     alignment_tool                              // string ["famsa", "mafft"]
     skip_msa_trimming                           // boolean
     clipkit_out_format                          // string (default: clipkit)
-    save_update_families_fasta                  // boolean
+    save_update_families_pre_clipped_fasta      // boolean
     save_update_families_clipped_fasta          // boolean
 
     main:
@@ -124,7 +124,7 @@ workflow UPDATE_FAMILIES {
     ALIGN_SEQUENCES( ch_fasta, alignment_tool )
     ch_versions = ch_versions.mix( ALIGN_SEQUENCES.out.versions )
 
-    if (save_update_families_fasta) {
+    if (save_update_families_pre_clipped_fasta && skip_sequence_redundancy_removal) { // else already saved in REMOVE_REDUNDANT_SEQS
         SEQKIT_SEQ_MSA_TO_FASTA( ALIGN_SEQUENCES.out.alignments )
         ch_versions = ch_versions.mix( SEQKIT_SEQ_MSA_TO_FASTA.out.versions.first() )
     }

--- a/subworkflows/local/update_families/tests/main.nf.test
+++ b/subworkflows/local/update_families/tests/main.nf.test
@@ -22,6 +22,8 @@ nextflow_workflow {
                 input[4] = "famsa"    // alignment_tool
                 input[5] = false      // skip_msa_trimming
                 input[6] = "clipkit"  // clipkit_out_format
+                input[7] = true      // save_update_families_fasta
+                input[8] = true       // save_update_families_clipped_fasta
                 """
             }
         }

--- a/subworkflows/local/update_families/tests/main.nf.test
+++ b/subworkflows/local/update_families/tests/main.nf.test
@@ -22,7 +22,7 @@ nextflow_workflow {
                 input[4] = "famsa"    // alignment_tool
                 input[5] = false      // skip_msa_trimming
                 input[6] = "clipkit"  // clipkit_out_format
-                input[7] = true      // save_update_families_fasta
+                input[7] = true       // save_update_families_pre_clipped_fasta
                 input[8] = true       // save_update_families_clipped_fasta
                 """
             }

--- a/subworkflows/local/update_families/tests/main.nf.test.snap
+++ b/subworkflows/local/update_families/tests/main.nf.test.snap
@@ -52,11 +52,6 @@
                     }
                 },
                 {
-                    "UPDATE_FAMILIES:SEQKIT_SEQ_MSA_TO_FASTA": {
-                        "seqkit": "v2.9.0"
-                    }
-                },
-                {
                     "UPDATE_FAMILIES:REMOVE_REDUNDANT_SEQS": {
                         "python": "3.13.1",
                         "biopython": 1.85
@@ -85,10 +80,10 @@
                 }
             ]
         ],
-        "timestamp": "2026-03-11T14:59:08.80916",
         "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "25.10.0"
-        }
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-03-12T09:25:09.689975864"
     }
 }

--- a/subworkflows/local/update_families/tests/main.nf.test.snap
+++ b/subworkflows/local/update_families/tests/main.nf.test.snap
@@ -37,6 +37,11 @@
                     }
                 },
                 {
+                    "UPDATE_FAMILIES:SEQKIT_SEQ_CLIPPED_MSA_TO_FASTA": {
+                        "seqkit": "v2.9.0"
+                    }
+                },
+                {
                     "UPDATE_FAMILIES:EXTRACT_FAMILY_REPS": {
                         "python": "3.13.1"
                     }
@@ -44,6 +49,11 @@
                 {
                     "UPDATE_FAMILIES:CLIPKIT": {
                         "clipkit": "2.4.1"
+                    }
+                },
+                {
+                    "UPDATE_FAMILIES:SEQKIT_SEQ_MSA_TO_FASTA": {
+                        "seqkit": "v2.9.0"
                     }
                 },
                 {
@@ -75,10 +85,10 @@
                 }
             ]
         ],
+        "timestamp": "2026-03-11T14:59:08.80916",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.4"
-        },
-        "timestamp": "2026-02-27T14:24:54.397463209"
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.0"
+        }
     }
 }

--- a/subworkflows/local/update_families/tests/nextflow.config
+++ b/subworkflows/local/update_families/tests/nextflow.config
@@ -4,6 +4,16 @@ process {
         ext.prefix = { "${meta.id}_${meta.family}" }
     }
 
+    withName: 'SEQKIT_SEQ_MSA_TO_FASTA' {
+        ext.args = "--remove-gaps"
+        ext.prefix = { "${meta.id}_${meta.family}" }
+    }
+
+    withName: 'SEQKIT_SEQ_CLIPPED_MSA_TO_FASTA' {
+        ext.args = "--remove-gaps"
+        ext.prefix = { "${meta.id}_${meta.family}" }
+    }
+
     withName: 'MMSEQS_CREATEDB' {
         ext.prefix = { "${meta.family}" }
     }
@@ -43,16 +53,7 @@ process {
     }
 
     withName: 'REMOVE_REDUNDANT_SEQS' {
-        ext.prefix = { "${meta.family}_${meta.id}" }
-    }
-
-    withName: 'SEQKIT_SEQ_MSA_TO_FASTA' {
-        ext.args = "--remove-gaps"
         ext.prefix = { "${meta.id}_${meta.family}" }
     }
 
-    withName: 'SEQKIT_SEQ_CLIPPED_MSA_TO_FASTA' {
-        ext.args = "--remove-gaps"
-        ext.prefix = { "${meta.id}_${meta.family}" }
-    }
 }

--- a/subworkflows/local/update_families/tests/nextflow.config
+++ b/subworkflows/local/update_families/tests/nextflow.config
@@ -48,11 +48,11 @@ process {
 
     withName: 'SEQKIT_SEQ_MSA_TO_FASTA' {
         ext.args = "--remove-gaps"
-        ext.prefix = { "${meta.family}" }
+        ext.prefix = { "${meta.id}_${meta.family}" }
     }
 
     withName: 'SEQKIT_SEQ_CLIPPED_MSA_TO_FASTA' {
         ext.args = "--remove-gaps"
-        ext.prefix = { "${meta.family}" }
+        ext.prefix = { "${meta.id}_${meta.family}" }
     }
 }

--- a/subworkflows/local/update_families/tests/nextflow.config
+++ b/subworkflows/local/update_families/tests/nextflow.config
@@ -45,4 +45,14 @@ process {
     withName: 'REMOVE_REDUNDANT_SEQS' {
         ext.prefix = { "${meta.family}_${meta.id}" }
     }
+
+    withName: 'SEQKIT_SEQ_MSA_TO_FASTA' {
+        ext.args = "--remove-gaps"
+        ext.prefix = { "${meta.family}" }
+    }
+
+    withName: 'SEQKIT_SEQ_CLIPPED_MSA_TO_FASTA' {
+        ext.args = "--remove-gaps"
+        ext.prefix = { "${meta.family}" }
+    }
 }

--- a/workflows/proteinfamilies.nf
+++ b/workflows/proteinfamilies.nf
@@ -82,7 +82,9 @@ workflow PROTEINFAMILIES {
         params.clustering_tool,
         params.alignment_tool,
         params.skip_msa_trimming,
-        params.clipkit_out_format
+        params.clipkit_out_format,
+        params.save_update_families_fasta,
+        params.save_update_families_clipped_fasta
     )
     ch_versions = ch_versions.mix( UPDATE_FAMILIES.out.versions )
 

--- a/workflows/proteinfamilies.nf
+++ b/workflows/proteinfamilies.nf
@@ -83,7 +83,7 @@ workflow PROTEINFAMILIES {
         params.alignment_tool,
         params.skip_msa_trimming,
         params.clipkit_out_format,
-        params.save_update_families_fasta,
+        params.save_update_families_pre_clipped_fasta,
         params.save_update_families_clipped_fasta
     )
     ch_versions = ch_versions.mix( UPDATE_FAMILIES.out.versions )


### PR DESCRIPTION
<!--
# nf-core/proteinfamilies pull request

Many thanks for contributing to nf-core/proteinfamilies!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/proteinfamilies/tree/main/.github/CONTRIBUTING.md)
-->

Closes #122 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/proteinfamilies/tree/main/.github/CONTRIBUTING.md)
- [x] If necessary, also make a PR on the nf-core/proteinfamilies _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

## Code changes 

1. `subworkflows/local/update_families/main.nf` — Added 2 `SEQKIT_SEQ` aliased imports, added `SEQKIT_SEQ_MSA_TO_FASTA` after `ALIGN_SEQUENCES`, added
  `SEQKIT_SEQ_CLIPPED_MSA_TO_FASTA` after `CLIPKIT`.
  2. `nextflow.config` — Added `save_update_families_fasta = false` and `save_update_families_non_redundant_fasta = false`.
  3. `conf/modules.config` — Updated `REMOVE_REDUNDANT_SEQS publishDir` to use the new param instead of `enabled: false`, changed its path to include
  `/fasta/`, added 2 new config blocks for `SEQKIT_SEQ_MSA_TO_FASTA` and `SEQKIT_SEQ_CLIPPED_MSA_TO_FASTA` with ``--remove-gaps ext.args`.
  4. Due to `seqkit/seq` module a `saveAs` workaround was applied that handles the published output filename, but the intermediate files in the work directory will still be `.fastq` since thats the hardcoded default in the module. That's fine since
    it's just an intermediate (for now?).
  5. `nextflow_schema.json` — Added both new params with descriptions and help text.