### PR TITLE
generate hmm lib files for filtered and raw out HMMs #156

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added`
 
-- [#159](https://github.com/nf-core/proteinfamilies/pull/159) - Added functionality to generate a HMM library file (compressed) with its respective final protein families HMMs, per each input sample row. Family library files can be found at `hmm/library` (by @juanfmx2) (Hackathon 2026) `🥚 <-- Congrats! you've found an easter egg!`
+- [#159](https://github.com/nf-core/proteinfamilies/pull/159) - Added functionality to generate a HMM library file (compressed) with its respective final protein families HMMs, per each input sample row. Family library files can be found at `hmm/library` (by @juanfmx2) (Hackathon 2026)
 - [#154](https://github.com/nf-core/proteinfamilies/pull/154) - Added optional save parameters for `update_families` mode: `--save_update_families_pre_clipped_fasta`, and `--save_update_families_clipped_fasta` (with gaps removed) to save FASTA files from updated family MSAs at various stages of the subworkflow (`update_families/fasta/pre_clipped/`, `update_families/fasta/pre_clipped_non_redundant_sequences/`, and `update_families/fasta/post_clipped/`). (by @eparisis) (Hackathon 2026)
 
 ### `Changed`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added`
 
+- [#159](https://github.com/nf-core/proteinfamilies/pull/159) - Added functionality to generate a HMM library file (compressed) with its respective final protein families HMMs, per each input sample row. Family library files can be found at `hmm/library` (by @juanfmx2) (Hackathon 2026) `🥚 <-- Congrats! you've found an easter egg!`
 - [#154](https://github.com/nf-core/proteinfamilies/pull/154) - Added optional save parameters for `update_families` mode: `--save_update_families_pre_clipped_fasta`, and `--save_update_families_clipped_fasta` (with gaps removed) to save FASTA files from updated family MSAs at various stages of the subworkflow (`update_families/fasta/pre_clipped/`, `update_families/fasta/pre_clipped_non_redundant_sequences/`, and `update_families/fasta/post_clipped/`). (by @eparisis) (Hackathon 2026)
 
 ### `Changed`

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -753,6 +753,15 @@ process {
         ]
     }
 
+    withName: '.*:PROTEINFAMILIES:FIND_CONCATENATE_HMM_LIBRARY' {
+        ext.prefix = { "${meta.id}.lib.gz" }
+        publishDir = [
+            path: { "${params.outdir}/hmm/library/" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
     withName: 'MULTIQC' {
         ext.args   = { params.multiqc_title ? "--title \"$params.multiqc_title\"" : '' }
         publishDir = [

--- a/docs/output.md
+++ b/docs/output.md
@@ -232,6 +232,8 @@ Results are stored in the `seed_msa/raw` folder.
   - `filtered/`
     - `<samplename>/`
       - `<samplename>_*.hmm.gz`: filtered non-redundant compressed hmm model for the family
+  - `library/`
+    - `<samplename>.lib.gz`: compressed compiled families HMM library model for the sample
   - `raw/`
     - `<samplename>/`
       - `<samplename>_*.hmm.gz`: compressed hmm model for the family
@@ -279,6 +281,7 @@ Results are stored in the `seed_msa/raw` folder.
 The `hmm/raw` folder contains all originally created family HMMs. These models will be used downstream to recruit additional sequences in families, to compute
 full MSAs if `--skip_additional_sequence_recruiting` is set to `false`, and/or to remove among-family redundancies if `--skip_family_redundancy_removal` is set to `false`.
 When `--skip_family_redundancy_removal` is set to `false`, the `hmm/filtered` folder will also be produced with the filtered subset of the original raw HMMs.
+The `hmm/library` will generate a compiled single HMM file library gzip file per each sample.
 The HMMs (raw or filtered) can also be used in the `update_families` execution mode of the pipeline,
 along with the families' respective full MSAs, to recruit sequences from a new input fasta file into the families, updating both family HMM and full MSA files.
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -281,7 +281,7 @@ Results are stored in the `seed_msa/raw` folder.
 The `hmm/raw` folder contains all originally created family HMMs. These models will be used downstream to recruit additional sequences in families, to compute
 full MSAs if `--skip_additional_sequence_recruiting` is set to `false`, and/or to remove among-family redundancies if `--skip_family_redundancy_removal` is set to `false`.
 When `--skip_family_redundancy_removal` is set to `false`, the `hmm/filtered` folder will also be produced with the filtered subset of the original raw HMMs.
-The `hmm/library` will generate a compiled single HMM file library gzip file per each sample.
+The `hmm/library` will contain a compiled single HMM file library gzip file per each sample.
 The HMMs (raw or filtered) can also be used in the `update_families` execution mode of the pipeline,
 along with the families' respective full MSAs, to recruit sequences from a new input fasta file into the families, updating both family HMM and full MSA files.
 

--- a/subworkflows/local/remove_redundancy/main.nf
+++ b/subworkflows/local/remove_redundancy/main.nf
@@ -215,6 +215,6 @@ workflow REMOVE_REDUNDANCY {
     emit:
     fasta    = fasta
     full_msa = full_msa
-    versions = ch_versions
     hmm      = ch_output_hmm
+    versions = ch_versions
 }

--- a/subworkflows/local/remove_redundancy/main.nf
+++ b/subworkflows/local/remove_redundancy/main.nf
@@ -45,6 +45,7 @@ workflow REMOVE_REDUNDANCY {
     ch_merged_fasta    = channel.empty()
     ch_merged_hmm      = channel.empty()
     ch_versions        = channel.empty()
+    ch_output_hmm      = channel.empty()
 
     // FAMILY REDUNDANCY REMOVAL MECHANISM
     if (!skip_family_redundancy_removal || !skip_family_merging) {
@@ -157,6 +158,8 @@ workflow REMOVE_REDUNDANCY {
 
         FILTER_NON_REDUNDANT_HMM( ch_input_for_fam_removal.model, ch_input_for_fam_removal.ids )
         ch_versions = ch_versions.mix( FILTER_NON_REDUNDANT_HMM.out.versions.first() )
+        ch_output_hmm = FILTER_NON_REDUNDANT_HMM.out.filtered
+            .transpose()   // unpack [meta, [f1,f2,...]] → individual [meta, file] tuples
 
         FILTER_NON_REDUNDANT_SEED_MSA( ch_input_for_fam_removal.seed, ch_input_for_fam_removal.ids )
         ch_versions = ch_versions.mix( FILTER_NON_REDUNDANT_SEED_MSA.out.versions.first() )
@@ -182,6 +185,8 @@ workflow REMOVE_REDUNDANCY {
                 def chunk = filename.split("${meta.id}_", 2)[1]  // Split by meta.id_ and take remainder, to also match merged ids
                 [[id: meta.id, chunk: chunk], file]
             }
+    } else {
+        ch_output_hmm = hmm  // raw individual [meta(id,chunk), file] tuples
     }
     // END FAMILY REDUNDANCY REMOVAL MECHANISM
 
@@ -211,4 +216,5 @@ workflow REMOVE_REDUNDANCY {
     fasta    = fasta
     full_msa = full_msa
     versions = ch_versions
+    hmm      = ch_output_hmm
 }

--- a/subworkflows/local/update_families/main.nf
+++ b/subworkflows/local/update_families/main.nf
@@ -157,8 +157,8 @@ workflow UPDATE_FAMILIES {
     ch_updated_family_reps = ch_updated_family_reps.mix( EXTRACT_FAMILY_REPS.out.map )
 
     emit:
-    versions            = ch_versions
     no_hit_seqs         = ch_no_hit_seqs
     updated_family_reps = ch_updated_family_reps
     hmm                 = HMMER_HMMBUILD.out.hmm
+    versions            = ch_versions
 }

--- a/subworkflows/local/update_families/main.nf
+++ b/subworkflows/local/update_families/main.nf
@@ -160,4 +160,5 @@ workflow UPDATE_FAMILIES {
     versions            = ch_versions
     no_hit_seqs         = ch_no_hit_seqs
     updated_family_reps = ch_updated_family_reps
+    hmm                 = HMMER_HMMBUILD.out.hmm
 }

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "-profile test": {
         "content": [
-            89,
+            90,
             {
                 "CALCULATE_CLUSTER_DISTRIBUTION": {
                     "sed": 4.7
@@ -39,6 +39,11 @@
                     "biopython": 1.85
                 },
                 "FIND_CONCATENATE_HMMS": {
+                    "find": "4.6.0",
+                    "pigz": 2.8,
+                    "coreutils": 9.4
+                },
+                "FIND_CONCATENATE_HMM_LIBRARY": {
                     "find": "4.6.0",
                     "pigz": 2.8,
                     "coreutils": 9.4
@@ -112,6 +117,8 @@
                 "hmm",
                 "hmm/filtered",
                 "hmm/filtered/mgnifams_test",
+                "hmm/library",
+                "hmm/library/mgnifams_test.lib.gz",
                 "hmm/raw",
                 "hmm/raw/mgnifams_test",
                 "mmseqs",
@@ -198,10 +205,10 @@
             "/full_msa/filtered/famsa_align/mgnifams_test: 5",
             "/fasta/non_redundant_sequences_filtered/mgnifams_test: 5"
         ],
+        "timestamp": "2026-03-13T15:06:24.102656",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
-        },
-        "timestamp": "2025-12-19T10:03:25.309570901"
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.4"
+        }
     }
 }

--- a/workflows/proteinfamilies.nf
+++ b/workflows/proteinfamilies.nf
@@ -9,19 +9,17 @@ include { paramsSummaryMultiqc   } from '../subworkflows/nf-core/utils_nfcore_pi
 include { softwareVersionsToYAML } from '../subworkflows/nf-core/utils_nfcore_pipeline'
 include { methodsDescriptionText } from '../subworkflows/local/utils_nfcore_proteinfamilies_pipeline'
 
-include { FAA_SEQFU_SEQKIT               } from '../subworkflows/nf-core/faa_seqfu_seqkit/main'
-include { UPDATE_FAMILIES                } from '../subworkflows/local/update_families'
-include { MMSEQS_FASTA_CLUSTER           } from '../subworkflows/nf-core/mmseqs_fasta_cluster'
-include { CALCULATE_CLUSTER_DISTRIBUTION } from '../modules/local/calculate_cluster_distribution/main'
-include { CHUNK_CLUSTERS                 } from '../modules/local/chunk_clusters/main'
-include { GENERATE_FAMILIES              } from '../subworkflows/local/generate_families'
-include { REMOVE_REDUNDANCY              } from '../subworkflows/local/remove_redundancy'
-include { CMAPLE                         } from '../modules/nf-core/cmaple/main'
-include { EXTRACT_FAMILY_MEMBERS         } from '../modules/local/extract_family_members/main'
-include { EXTRACT_FAMILY_REPS            } from '../modules/local/extract_family_reps/main'
-include {
-    FIND_CONCATENATE as FIND_CONCATENATE_HMM_LIBRARY
-} from '../modules/nf-core/find/concatenate'
+include { FAA_SEQFU_SEQKIT                                 } from '../subworkflows/nf-core/faa_seqfu_seqkit/main'
+include { UPDATE_FAMILIES                                  } from '../subworkflows/local/update_families'
+include { MMSEQS_FASTA_CLUSTER                             } from '../subworkflows/nf-core/mmseqs_fasta_cluster'
+include { CALCULATE_CLUSTER_DISTRIBUTION                   } from '../modules/local/calculate_cluster_distribution/main'
+include { CHUNK_CLUSTERS                                   } from '../modules/local/chunk_clusters/main'
+include { GENERATE_FAMILIES                                } from '../subworkflows/local/generate_families'
+include { REMOVE_REDUNDANCY                                } from '../subworkflows/local/remove_redundancy'
+include { CMAPLE                                           } from '../modules/nf-core/cmaple/main'
+include { EXTRACT_FAMILY_MEMBERS                           } from '../modules/local/extract_family_members/main'
+include { EXTRACT_FAMILY_REPS                              } from '../modules/local/extract_family_reps/main'
+include { FIND_CONCATENATE as FIND_CONCATENATE_HMM_LIBRARY } from '../modules/nf-core/find/concatenate'
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -149,6 +147,7 @@ workflow PROTEINFAMILIES {
         params.hmmsearch_query_length_threshold
     )
     ch_versions = ch_versions.mix( REMOVE_REDUNDANCY.out.versions )
+
     // Collect all final HMMs per sample and concatenate into a .lib.gz library
     ch_hmm_for_library = UPDATE_FAMILIES.out.hmm
         .map { meta, model -> [ [id: meta.id], model ] }

--- a/workflows/proteinfamilies.nf
+++ b/workflows/proteinfamilies.nf
@@ -19,6 +19,9 @@ include { REMOVE_REDUNDANCY              } from '../subworkflows/local/remove_re
 include { CMAPLE                         } from '../modules/nf-core/cmaple/main'
 include { EXTRACT_FAMILY_MEMBERS         } from '../modules/local/extract_family_members/main'
 include { EXTRACT_FAMILY_REPS            } from '../modules/local/extract_family_reps/main'
+include {
+    FIND_CONCATENATE as FIND_CONCATENATE_HMM_LIBRARY
+} from '../modules/nf-core/find/concatenate'
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -146,6 +149,17 @@ workflow PROTEINFAMILIES {
         params.hmmsearch_query_length_threshold
     )
     ch_versions = ch_versions.mix( REMOVE_REDUNDANCY.out.versions )
+    // Collect all final HMMs per sample and concatenate into a .lib.gz library
+    ch_hmm_for_library = UPDATE_FAMILIES.out.hmm
+        .map { meta, model -> [ [id: meta.id], model ] }
+        .mix(
+            REMOVE_REDUNDANCY.out.hmm
+                .map { meta, model -> [ [id: meta.id], model ] }
+        )
+        .groupTuple()
+
+    FIND_CONCATENATE_HMM_LIBRARY( ch_hmm_for_library )
+    ch_versions = ch_versions.mix( FIND_CONCATENATE_HMM_LIBRARY.out.versions.first() )
 
     // Infer Phylogenetic relations of full MSAs
     if (!params.skip_phylogenetic_inference) {

--- a/workflows/proteinfamilies.nf
+++ b/workflows/proteinfamilies.nf
@@ -16,10 +16,10 @@ include { CALCULATE_CLUSTER_DISTRIBUTION                   } from '../modules/lo
 include { CHUNK_CLUSTERS                                   } from '../modules/local/chunk_clusters/main'
 include { GENERATE_FAMILIES                                } from '../subworkflows/local/generate_families'
 include { REMOVE_REDUNDANCY                                } from '../subworkflows/local/remove_redundancy'
+include { FIND_CONCATENATE as FIND_CONCATENATE_HMM_LIBRARY } from '../modules/nf-core/find/concatenate'
 include { CMAPLE                                           } from '../modules/nf-core/cmaple/main'
 include { EXTRACT_FAMILY_MEMBERS                           } from '../modules/local/extract_family_members/main'
 include { EXTRACT_FAMILY_REPS                              } from '../modules/local/extract_family_reps/main'
-include { FIND_CONCATENATE as FIND_CONCATENATE_HMM_LIBRARY } from '../modules/nf-core/find/concatenate'
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Adds functionality requested in #156 to generate HMM families library files per sample.

closes #156

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [X] If you've fixed a bug or added code that should be tested, add tests!
- [X] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/proteinfamilies/tree/main/.github/CONTRIBUTING.md)
- [X] Make sure your code lints (`nf-core pipelines lint`).
- [X] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [X] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
