### PR TITLE
Fix long merged id filename issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
-- [#177](https://github.com/nf-core/proteinfamilies/pull/177) - Fixed `OSError: [Errno 36] File name too long` in `MERGE_FAMILIES:MERGE_SEEDS` when a pool combines many families: `merged_id` now collapses to a stable hash once the readable form would exceed the filesystem name-length limit. (by @vagkaratzas, bug reported by @Yixuan39)
+- [#177](https://github.com/nf-core/proteinfamilies/pull/177)
+  - Fixed `OSError: [Errno 36] File name too long` in `MERGE_FAMILIES:MERGE_SEEDS` when a pool combines many families: `merged_id` now collapses to a stable hash once the readable form would exceed the filesystem name-length limit. (by @vagkaratzas, bug reported by @Yixuan39)
+  - Fixed `FAMSA_ALIGN` aborting with exit status 134 on merged families: `MERGE_SEEDS` now drops all-gap records, which `CLIPKIT` can leave behind when a member's residues all fall in trimmed columns, and which FAMSA cannot realign. (by @vagkaratzas, bug reported by @Yixuan39)
 
 ## v2.4.0 - [2026/06/09]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## v2.5.0dev - [unreleased]
 
+### `Fixed`
+
+- [#177](https://github.com/nf-core/proteinfamilies/pull/177) - Fixed `OSError: [Errno 36] File name too long` in `MERGE_FAMILIES:MERGE_SEEDS` when a pool combines many families: `merged_id` now collapses to a stable hash once the readable form would exceed the filesystem name-length limit. (by @vagkaratzas, bug reported by @Yixuan39)
+
 ## v2.4.0 - [2026/06/09]
 
 ### `Changed`

--- a/bin/merge_seeds.py
+++ b/bin/merge_seeds.py
@@ -44,6 +44,31 @@ def parse_args(args: Sequence[str] | None = None) -> argparse.Namespace:
     return parser.parse_args(args)
 
 
+def keep_non_empty_records(content: str) -> list[str]:
+    """
+    Split a FASTA alignment into records, dropping any that contain no residues.
+
+    Gap-trimming (ClipKIT) removes columns but never rows, so a member whose residues all
+    fell inside the trimmed columns survives as an all-gap record. Such records carry no
+    sequence and abort the downstream realignment (FAMSA), so they are filtered out here.
+
+    Args:
+        content (str): Contents of a FASTA-format alignment file.
+
+    Returns:
+        list[str]: Records that still hold at least one residue, as FASTA blocks.
+    """
+    kept = []
+
+    for record in content.split(">")[1:]:
+        header, _, sequence = record.partition("\n")
+        # '-' and '.' are both gap characters in the alignment formats handled here
+        if sequence.replace("-", "").replace(".", "").strip():
+            kept.append(f">{header}\n{sequence.strip()}")
+
+    return kept
+
+
 def merge_selected_alignments(family_ids: list[str], folder: str, out_file: str) -> None:
     """
     Merge seed alignments whose basename matches one of the requested family IDs.
@@ -54,6 +79,8 @@ def merge_selected_alignments(family_ids: list[str], folder: str, out_file: str)
         out_file (str): Output path for the merged alignment file.
     """
     merged_contents = []
+    merged_files = 0
+    dropped_records = 0
 
     for fam in family_ids:
         fname = next((os.path.join(folder, f) for f in os.listdir(folder) if os.path.splitext(f)[0] == fam), None)
@@ -61,15 +88,22 @@ def merge_selected_alignments(family_ids: list[str], folder: str, out_file: str)
             with open(fname, "r") as f:
                 content = f.read().strip()
                 if content:
-                    merged_contents.append(content)
+                    kept = keep_non_empty_records(content)
+                    dropped_records += content.count(">") - len(kept)
+                    if kept:
+                        merged_contents.extend(kept)
+                        merged_files += 1
         else:
             print(f"[WARNING] File not found: {fname}", file=sys.stderr)
+
+    if dropped_records:
+        print(f"[WARNING] Dropped {dropped_records} all-gap record(s) while merging.", file=sys.stderr)
 
     if merged_contents:
         with open(out_file, "w") as out:
             # Literal concatenation of FASTA blocks — valid for any FASTA-format alignment.
             out.write("\n".join(merged_contents) + "\n")
-        print(f"[INFO] Merged {len(merged_contents)} files into {out_file}")
+        print(f"[INFO] Merged {merged_files} files into {out_file}")
     else:
         print("[WARNING] No files merged (none matched the provided list).", file=sys.stderr)
 

--- a/modules/local/merge_seeds/tests/main.nf.test
+++ b/modules/local/merge_seeds/tests/main.nf.test
@@ -35,6 +35,55 @@ nextflow_process {
         }
     }
 
+    test("proteinfamilies - aln - all-gap records dropped") {
+        // Regression test for the FAMSA_ALIGN abort (exit 134, profile.cpp:773) on merged families.
+        // ClipKIT trims columns but never rows, so a member whose residues all sat in trimmed
+        // columns reaches MERGE_SEEDS as an all-gap record. FAMSA strips the gaps, is left with a
+        // zero-length sequence and aborts, so such records must not make it into the merged seed.
+        when {
+            process {
+                """
+                def fam1 = file('all_gap_test_1.aln')
+                fam1.text = '''>keep_1
+                    |MKVLATGGH--KLS
+                    |>all_gap_1
+                    |--------------
+                    |>keep_2
+                    |MKVLA-GGHRRKLS
+                    |'''.stripMargin()
+
+                def fam2 = file('all_gap_test_2.aln')
+                // '.' is also a gap character; a record made only of gap characters carries no residue
+                fam2.text = '''>keep_3
+                    |MKILATGGH--KLS
+                    |>all_gap_2
+                    |...--.........
+                    |'''.stripMargin()
+
+                input[0] = channel.of([
+                    [ id: 'test_similarities', merged_id: 'all_gap_1_2' ],
+                    "all_gap_test_1,all_gap_test_2",
+                ])
+                input[1] = channel.of([ [ id: 'test_aln' ], [ fam1, fam2 ] ])
+                """
+            }
+        }
+
+        then {
+            def merged = file(process.out.merged_seed_msa[0][1]).text
+            assertAll(
+                { assert process.success },
+                // The three residue-carrying records survive, the two all-gap ones are gone
+                { assert snapshot(
+                    merged.count('>'),
+                    merged.contains('all_gap_1'),
+                    merged.contains('all_gap_2'),
+                    process.out.merged_seed_msa
+                    ).match()}
+            )
+        }
+    }
+
     test("proteinfamilies - aln - stub") {
 
         options "-stub"

--- a/modules/local/merge_seeds/tests/main.nf.test.snap
+++ b/modules/local/merge_seeds/tests/main.nf.test.snap
@@ -68,5 +68,26 @@
             "nf-test": "0.9.5",
             "nextflow": "26.04.3"
         }
+    },
+    "proteinfamilies - aln - all-gap records dropped": {
+        "content": [
+            3,
+            false,
+            false,
+            [
+                [
+                    {
+                        "id": "test_similarities",
+                        "merged_id": "all_gap_1_2"
+                    },
+                    "all_gap_1_2.fas:md5,7428156e5c01347fe7c1a1f71245c3f8"
+                ]
+            ]
+        ],
+        "timestamp": "2026-07-22T08:50:01.98973476",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.4"
+        }
     }
 }

--- a/subworkflows/local/merge_families/main.nf
+++ b/subworkflows/local/merge_families/main.nf
@@ -4,7 +4,8 @@
     Groups similar families into pools, merges their seed MSAs into a single combined
     seed, then rebuilds final family models via GENERATE_FAMILIES. The merged_id
     encodes which original families were combined (e.g., 'sample_1_7' from 'sample_1'
-    and 'sample_7').
+    and 'sample_7'); for very large pools it collapses to a stable hash so the
+    resulting output filename stays within the filesystem's name-length limit.
 */
 
 include { POOL_SIMILAR_COMPONENTS } from '../../../modules/local/pool_similar_components/main'
@@ -35,10 +36,16 @@ workflow MERGE_FAMILIES {
             def suffixes = components.collect { component ->
                 component.split('_').last()
             }
-            // Join the suffixes with underscores
-            def combinedSuffix = suffixes.join('_')
+            // Readable id encoding every combined family, e.g. 'sample_1_7'
+            def readableId = "${meta.id}_${suffixes.join('_')}"
+            // merged_id becomes the output-file prefix for every merged-family process, so it
+            // must fit the filesystem's 255-byte name limit. Large pools (dozens of families)
+            // would overflow it; in that case fall back to a short, stable hash of the members.
+            def merged_id = readableId.length() <= 200
+                ? readableId
+                : "${meta.id}_${suffixes.size()}fams_${suffixes.join('_').md5().take(10)}"
             // Keep original id, add new field merged_id
-            def newMeta = meta + [merged_id: "${meta.id}_${combinedSuffix}"]
+            def newMeta = meta + [merged_id: merged_id]
             return [newMeta, components.join(',')]
         }
 

--- a/subworkflows/local/merge_families/tests/main.nf.test
+++ b/subworkflows/local/merge_families/tests/main.nf.test
@@ -53,4 +53,68 @@ nextflow_workflow {
         }
     }
 
+    test("large pool - merged_id stays within filename length limit") {
+        // Regression test for the 'OSError: [Errno 36] File name too long' crash in MERGE_SEEDS
+        // when a pool combines many families. The two real seed MSAs are duplicated under 90
+        // distinct family names (headers made unique) and chained into a single connected
+        // component, so merged_id would exceed the filesystem's name limit unless it collapses
+        // to the bounded hash form.
+        when {
+            workflow {
+                """
+                def n = 90
+                def fams = (1..n).collect { "mgnifams_test_\${it}" }
+
+                // Reuse the existing fixtures, alternating between the two
+                def alns = [
+                    file(params.pipelines_testdata_base_path + 'test_data/modules/mgnifams_test_1.aln', checkIfExists: true).text,
+                    file(params.pipelines_testdata_base_path + 'test_data/modules/mgnifams_test_2.aln', checkIfExists: true).text
+                ]
+                def seedFiles = fams.withIndex().collect { fam, i ->
+                    def f = file("\${fam}.aln")
+                    // Prefix every header with the family id so the merged seed has unique names
+                    f.text = alns[i % 2].replaceAll(/(?m)^>/, ">\${fam}_")
+                    f
+                }
+
+                // Chain the families into one connected component (transitive closure -> one pool)
+                def rows = (0..<n - 1).collect { "\${fams[it]},\${fams[it + 1]},0.94" }.join('\\n')
+                def similarities_file = file('similarities_large_pool.csv')
+                similarities_file.text = "family_1,family_2,similarity_score\\n" + rows + "\\n"
+
+                input[0] = [ [ id: 'test' ], similarities_file ]
+                input[1] = channel.of([ [ id: 'test' ], seedFiles ])
+                input[2] = channel.of([
+                    [ id: 'test' ],
+                    file(params.pipelines_testdata_base_path + 'test_data/mgnifams_input_small.faa', checkIfExists: true)
+                ])
+                input[3] = "famsa"   // alignment_tool
+                input[4] = false     // skip_msa_trimming
+                input[5] = "clipkit" // clipkit_out_format
+                input[6] = false     // hmmsearch_write_target
+                input[7] = true      // hmmsearch_write_domain
+                input[8] = false     // skip_additional_sequence_recruiting
+                input[9] = 0.9       // hmmsearch_query_length_threshold
+                """
+            }
+        }
+
+        then {
+            def merged_name = file(workflow.out.hmm[0][1]).name
+            assertAll(
+                // No 'File name too long' crash in MERGE_SEEDS
+                { assert workflow.success },
+                { assert snapshot(
+                    // merged_id collapsed to the bounded hash form instead of a 200+ char name
+                    merged_name,
+                    merged_name ==~ /test_\d+fams_[0-9a-f]{10}\.hmm.gz/,
+                    merged_name.length() < 200,
+                    workflow.out.seed_msa,
+                    workflow.out.full_msa,
+                    workflow.out.fasta
+                ).match()}
+            )
+        }
+    }
+
 }

--- a/subworkflows/local/merge_families/tests/main.nf.test.snap
+++ b/subworkflows/local/merge_families/tests/main.nf.test.snap
@@ -1,4 +1,43 @@
 {
+    "large pool - merged_id stays within filename length limit": {
+        "content": [
+            "test_90fams_cef0de0010.hmm.gz",
+            true,
+            true,
+            [
+                [
+                    {
+                        "id": "test",
+                        "merged_id": "test_90fams_cef0de0010"
+                    },
+                    "test_90fams_cef0de0010.clipkit:md5,7c92708da123702944bbfec1341edd38"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "merged_id": "test_90fams_cef0de0010"
+                    },
+                    "test_90fams_cef0de0010.sto.gz:md5,b432795e4a56a2284d2bce48066beb99"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "merged_id": "test_90fams_cef0de0010"
+                    },
+                    "test_90fams_cef0de0010.fasta.gz:md5,f398708f15b7e8a5e28dcb7c4f653e40"
+                ]
+            ]
+        ],
+        "timestamp": "2026-07-15T17:03:36.38742161",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.4"
+        }
+    },
     "fasta": {
         "content": [
             "test_1_2.hmm.gz",


### PR DESCRIPTION
Closes #176 

### `Fixed`

- [#177](https://github.com/nf-core/proteinfamilies/pull/177)
  - Fixed `OSError: [Errno 36] File name too long` in `MERGE_FAMILIES:MERGE_SEEDS` when a pool combines many families: `merged_id` now collapses to a stable hash once the readable form would exceed the filesystem name-length limit. (by @vagkaratzas, bug reported by @Yixuan39)
  - Fixed `FAMSA_ALIGN` aborting with exit status 134 on merged families: `MERGE_SEEDS` now drops all-gap records, which `CLIPKIT` can leave behind when a member's residues all fall in trimmed columns, and which FAMSA cannot realign. (by @vagkaratzas, bug reported by @Yixuan39)

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/proteinfamilies/tree/main/docs/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/proteinfamilies _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
